### PR TITLE
early out also clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@
 Language: Cpp
 BasedOnStyle: Google
 IndentWidth: 2
-ContinuationIndentWidth: 2
+ContinuationIndentWidth: 4
 PPIndentWidth: 2
 ColumnLimit: 91
 IndentCaseLabels: true

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,36 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+ContinuationIndentWidth: 2
+PPIndentWidth: 2
+ColumnLimit: 91
+IndentCaseLabels: true
+Cpp11BracedListStyle: false
+IncludeBlocks: Preserve
+
+AlignAfterOpenBracket: Align
+AlignEscapedNewlines: DontAlign
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortLoopsOnASingleLine: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AlwaysBreakAfterReturnType: None
+
+BinPackArguments: false
+BinPackParameters: false
+
+BitFieldColonSpacing: Both
+
+InsertTrailingCommas: Wrapped
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+MaxEmptyLinesToKeep: 1
+
+ReflowComments: true
+SpaceAfterCStyleCast: false
+---
+Language: Proto
+BasedOnStyle: Google

--- a/nanolog.c
+++ b/nanolog.c
@@ -5,26 +5,32 @@
 #include <wchar.h>
 
 #ifdef _MSC_VER
-#include <assert.h> // _Static_assert on msvc
+#include <assert.h>  // _Static_assert on msvc
 #endif
 
 static nanolog_handler_cb_t s_log_handler = NULL;
 static unsigned s_log_threshold = NL_SEV_DEBUG;
 
 nanolog_ret_t nanolog_set_threshold(unsigned severity) {
-  if (severity > NL_SEV_ASSERT) { return NANOLOG_RET_ERR_BAD_ARG; }
+  if (severity > NL_SEV_ASSERT) {
+    return NANOLOG_RET_ERR_BAD_ARG;
+  }
   s_log_threshold = severity;
   return NANOLOG_RET_SUCCESS;
 }
 
-unsigned nanolog_get_threshold(void) { return s_log_threshold; }
+unsigned nanolog_get_threshold(void) {
+  return s_log_threshold;
+}
 
 nanolog_ret_t nanolog_set_handler(nanolog_handler_cb_t handler) {
   s_log_handler = handler;
   return NANOLOG_RET_SUCCESS;
 }
 
-nanolog_handler_cb_t nanolog_get_handler(void) { return s_log_handler; }
+nanolog_handler_cb_t nanolog_get_handler(void) {
+  return s_log_handler;
+}
 
 #ifdef _MSC_VER
 #define NL_NOINLINE __declspec(noinline)
@@ -37,7 +43,9 @@ nanolog_handler_cb_t nanolog_get_handler(void) { return s_log_handler; }
 #endif
 
 NL_NOINLINE void nanolog_log_sev(unsigned sev, char const *fmt, ...) {
-  if (!s_log_handler || (s_log_threshold > sev)) { return; }
+  if (!s_log_handler || (s_log_threshold > sev)) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
   s_log_handler(NULL, sev | NL_DYNAMIC_SEV_BIT, NULL, 0, fmt, a);
@@ -45,7 +53,9 @@ NL_NOINLINE void nanolog_log_sev(unsigned sev, char const *fmt, ...) {
 }
 
 NL_NOINLINE void nanolog_log_sev_ctx(unsigned sev, void *ctx, char const *fmt, ...) {
-  if (!s_log_handler || (s_log_threshold > sev)) { return; }
+  if (!s_log_handler || (s_log_threshold > sev)) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
   s_log_handler(ctx, sev | NL_DYNAMIC_SEV_BIT, NULL, 0, fmt, a);
@@ -58,7 +68,9 @@ NL_NOINLINE void nanolog_log_buf(unsigned sev,
                                  unsigned len,
                                  char const *fmt,
                                  ...) {
-  if (!s_log_handler || (s_log_threshold > sev)) { return; }
+  if (!s_log_handler || (s_log_threshold > sev)) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
   s_log_handler(ctx, sev | NL_DYNAMIC_SEV_BIT, buf, len, fmt, a);
@@ -66,15 +78,19 @@ NL_NOINLINE void nanolog_log_buf(unsigned sev,
 }
 
 NL_NOINLINE void nanolog_log_debug(char const *fmt, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_DEBUG)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_DEBUG)) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
-  s_log_handler(NULL, NL_SEV_DEBUG, NULL, 0,  fmt, a);
+  s_log_handler(NULL, NL_SEV_DEBUG, NULL, 0, fmt, a);
   va_end(a);
 }
 
 NL_NOINLINE void nanolog_log_debug_ctx(char const *fmt, void *ctx, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_DEBUG)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_DEBUG)) {
+    return;
+  }
   va_list a;
   va_start(a, ctx);
   s_log_handler(ctx, NL_SEV_DEBUG, NULL, 0, fmt, a);
@@ -82,7 +98,9 @@ NL_NOINLINE void nanolog_log_debug_ctx(char const *fmt, void *ctx, ...) {
 }
 
 NL_NOINLINE void nanolog_log_info(char const *fmt, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_INFO)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_INFO)) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
   s_log_handler(NULL, NL_SEV_INFO, NULL, 0, fmt, a);
@@ -90,7 +108,9 @@ NL_NOINLINE void nanolog_log_info(char const *fmt, ...) {
 }
 
 NL_NOINLINE void nanolog_log_info_ctx(char const *fmt, void *ctx, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_INFO)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_INFO)) {
+    return;
+  }
   va_list a;
   va_start(a, ctx);
   s_log_handler(ctx, NL_SEV_INFO, NULL, 0, fmt, a);
@@ -98,7 +118,9 @@ NL_NOINLINE void nanolog_log_info_ctx(char const *fmt, void *ctx, ...) {
 }
 
 NL_NOINLINE void nanolog_log_warning(char const *fmt, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_WARNING)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_WARNING)) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
   s_log_handler(NULL, NL_SEV_WARNING, NULL, 0, fmt, a);
@@ -106,7 +128,9 @@ NL_NOINLINE void nanolog_log_warning(char const *fmt, ...) {
 }
 
 NL_NOINLINE void nanolog_log_warning_ctx(char const *fmt, void *ctx, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_WARNING)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_WARNING)) {
+    return;
+  }
   va_list a;
   va_start(a, ctx);
   s_log_handler(ctx, NL_SEV_WARNING, NULL, 0, fmt, a);
@@ -114,7 +138,9 @@ NL_NOINLINE void nanolog_log_warning_ctx(char const *fmt, void *ctx, ...) {
 }
 
 NL_NOINLINE void nanolog_log_error(char const *fmt, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_ERROR)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_ERROR)) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
   s_log_handler(NULL, NL_SEV_ERROR, NULL, 0, fmt, a);
@@ -122,7 +148,9 @@ NL_NOINLINE void nanolog_log_error(char const *fmt, ...) {
 }
 
 NL_NOINLINE void nanolog_log_error_ctx(char const *fmt, void *ctx, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_ERROR)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_ERROR)) {
+    return;
+  }
   va_list a;
   va_start(a, ctx);
   s_log_handler(ctx, NL_SEV_ERROR, NULL, 0, fmt, a);
@@ -130,7 +158,9 @@ NL_NOINLINE void nanolog_log_error_ctx(char const *fmt, void *ctx, ...) {
 }
 
 NL_NOINLINE void nanolog_log_critical(char const *fmt, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_CRITICAL)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_CRITICAL)) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
   s_log_handler(NULL, NL_SEV_CRITICAL, NULL, 0, fmt, a);
@@ -138,7 +168,9 @@ NL_NOINLINE void nanolog_log_critical(char const *fmt, ...) {
 }
 
 NL_NOINLINE void nanolog_log_critical_ctx(char const *fmt, void *ctx, ...) {
-  if (!s_log_handler || (s_log_threshold > NL_SEV_CRITICAL)) { return; }
+  if (!s_log_handler || (s_log_threshold > NL_SEV_CRITICAL)) {
+    return;
+  }
   va_list a;
   va_start(a, ctx);
   s_log_handler(ctx, NL_SEV_CRITICAL, NULL, 0, fmt, a);
@@ -146,7 +178,9 @@ NL_NOINLINE void nanolog_log_critical_ctx(char const *fmt, void *ctx, ...) {
 }
 
 NL_NOINLINE void nanolog_log_assert(char const *fmt, ...) {
-  if (!s_log_handler) { return; }
+  if (!s_log_handler) {
+    return;
+  }
   va_list a;
   va_start(a, fmt);
   s_log_handler(NULL, NL_SEV_ASSERT, NULL, 0, fmt, a);
@@ -154,7 +188,9 @@ NL_NOINLINE void nanolog_log_assert(char const *fmt, ...) {
 }
 
 NL_NOINLINE void nanolog_log_assert_ctx(char const *fmt, void *ctx, ...) {
-  if (!s_log_handler) { return; }
+  if (!s_log_handler) {
+    return;
+  }
   va_list a;
   va_start(a, ctx);
   s_log_handler(ctx, NL_SEV_ASSERT, NULL, 0, fmt, a);
@@ -162,7 +198,9 @@ NL_NOINLINE void nanolog_log_assert_ctx(char const *fmt, void *ctx, ...) {
 }
 
 nanolog_ret_t nanolog_fmt_is_binary(char const *fmt, int *out_is_binary) {
-  if (!fmt || !out_is_binary) { return NANOLOG_RET_ERR_BAD_ARG; }
+  if (!fmt || !out_is_binary) {
+    return NANOLOG_RET_ERR_BAD_ARG;
+  }
   *out_is_binary = (fmt[0] == NL_BINARY_LOG_MARKER);
   return NANOLOG_RET_SUCCESS;
 }
@@ -174,21 +212,27 @@ nanolog_ret_t nanolog_parse_binary_log(nanolog_binary_field_handler_cb_t cb,
                                        unsigned buf_len,
                                        char const *fmt,
                                        va_list args) {
-  if (!cb || !fmt) { return NANOLOG_RET_ERR_BAD_ARG; }
+  if (!cb || !fmt) {
+    return NANOLOG_RET_ERR_BAD_ARG;
+  }
 
   unsigned char const *src = (unsigned char const *)fmt;
-  if (*src++ != NL_BINARY_LOG_MARKER) { return NANOLOG_RET_ERR_INVALID_PAYLOAD; }
+  if (*src++ != NL_BINARY_LOG_MARKER) {
+    return NANOLOG_RET_ERR_INVALID_PAYLOAD;
+  }
 
   // About to log, tell user so they can transmit timestamp etc
   cb(ctx, NL_ARG_TYPE_LOG_START, NULL, 0);
 
-  { // GUID is varint-encoded, ends at first byte w/o a high "continuation" bit (0x80)
+  {  // GUID is varint-encoded, ends at first byte w/o a high "continuation" bit (0x80)
     unsigned char const *guid = src;
-    while (*src & 0x80) { ++src; }
+    while (*src & 0x80) {
+      ++src;
+    }
     cb(ctx, NL_ARG_TYPE_GUID, guid, (unsigned)(++src - guid));
   }
 
-  if (sev & NL_DYNAMIC_SEV_BIT) { // nanolog_log_sev[_ctx]
+  if (sev & NL_DYNAMIC_SEV_BIT) {  // nanolog_log_sev[_ctx]
     _Static_assert(NL_DYNAMIC_SEV_BIT > 255, "");
     uint8_t const sev_byte = (uint8_t)sev;
     cb(ctx, NL_ARG_TYPE_DYNAMIC_SEVERITY, &sev_byte, 1);
@@ -200,69 +244,92 @@ nanolog_ret_t nanolog_parse_binary_log(nanolog_binary_field_handler_cb_t cb,
   nl_arg_type_t type;
   do {
     type = (nl_arg_type_t)((*src >> (hi ? 4 : 0)) & 0xF);
-    if ((hi = !hi) == 0) { ++src; }
+    if ((hi = !hi) == 0) {
+      ++src;
+    }
 
     switch (type) {
       case NL_ARG_TYPE_SCALAR_1_BYTE: {
-        char const c = (char)va_arg(args, int); cb(ctx, type, &c, sizeof(c));
+        char const c = (char)va_arg(args, int);
+        cb(ctx, type, &c, sizeof(c));
       } break;
 
       case NL_ARG_TYPE_SCALAR_2_BYTE: {
-        short const s = (short)va_arg(args, int); cb(ctx, type, &s, sizeof(s));
+        short const s = (short)va_arg(args, int);
+        cb(ctx, type, &s, sizeof(s));
       } break;
 
       case NL_ARG_TYPE_SCALAR_4_BYTE: {
-        int const i = va_arg(args, int); cb(ctx, type, &i, sizeof(i));
+        int const i = va_arg(args, int);
+        cb(ctx, type, &i, sizeof(i));
       } break;
 
       case NL_ARG_TYPE_SCALAR_8_BYTE: {
-        long long const ll = va_arg(args, long long); cb(ctx, type, &ll, sizeof(ll));
+        long long const ll = va_arg(args, long long);
+        cb(ctx, type, &ll, sizeof(ll));
       } break;
 
       case NL_ARG_TYPE_STRING: {
         char const *s = va_arg(args, char const *);
         unsigned sl = 0, len_enc_len = 0;
-        for (char const *c = s; *c && (!have_prec || (sl < (unsigned)prec)); ++c, ++sl);
+        for (char const *c = s; *c && (!have_prec || (sl < (unsigned)prec)); ++c, ++sl)
+          ;
         unsigned char len_enc[8];
-        if (nanolog_varint_encode(sl, len_enc, sizeof(len_enc), &len_enc_len)
-          != NANOLOG_RET_SUCCESS) { return NANOLOG_RET_ERR_INTERNAL; }
+        if (nanolog_varint_encode(sl, len_enc, sizeof(len_enc), &len_enc_len) !=
+            NANOLOG_RET_SUCCESS) {
+          return NANOLOG_RET_ERR_INTERNAL;
+        }
         cb(ctx, NL_ARG_TYPE_STRING_LEN, len_enc, len_enc_len);
         cb(ctx, NL_ARG_TYPE_STRING, s, sl);
       } break;
 
       case NL_ARG_TYPE_POINTER: {
-        void *const v = va_arg(args, void *); cb(ctx, type, &v, sizeof(v));
+        void *const v = va_arg(args, void *);
+        cb(ctx, type, &v, sizeof(v));
       } break;
 
       case NL_ARG_TYPE_DOUBLE: {
-        double const d = va_arg(args, double); cb(ctx, type, &d, sizeof(d));
+        double const d = va_arg(args, double);
+        cb(ctx, type, &d, sizeof(d));
       } break;
 
       case NL_ARG_TYPE_LONG_DOUBLE: {
-        long double const ld = va_arg(args, long double); cb(ctx, type, &ld, sizeof(ld));
+        long double const ld = va_arg(args, long double);
+        cb(ctx, type, &ld, sizeof(ld));
       } break;
 
       case NL_ARG_TYPE_WINT_T: {
-        wint_t const w = va_arg(args, wint_t); cb(ctx, type, &w, sizeof(w));
+        wint_t const w = va_arg(args, wint_t);
+        cb(ctx, type, &w, sizeof(w));
       } break;
 
-      case NL_ARG_TYPE_PRECISION_STAR: have_prec = 1; NL_FALLTHROUGH;
+      case NL_ARG_TYPE_PRECISION_STAR:
+        have_prec = 1;
+        NL_FALLTHROUGH;
       case NL_ARG_TYPE_FIELD_WIDTH_STAR: {
         unsigned char vi[8];
         unsigned vil = 0;
         prec = (int32_t)va_arg(args, int);
-        if (nanolog_varint_encode(nanolog_zigzag_encode(prec), vi, sizeof(vi), &vil)
-          != NANOLOG_RET_SUCCESS) { return NANOLOG_RET_ERR_INTERNAL; }
-        if (have_prec && (prec < 0)) { have_prec = 0; }
+        if (nanolog_varint_encode(nanolog_zigzag_encode(prec), vi, sizeof(vi), &vil) !=
+            NANOLOG_RET_SUCCESS) {
+          return NANOLOG_RET_ERR_INTERNAL;
+        }
+        if (have_prec && (prec < 0)) {
+          have_prec = 0;
+        }
         cb(ctx, type, vi, vil);
       } break;
 
       case NL_ARG_TYPE_STRING_PRECISION_LITERAL: {
-        if (hi) { ++src; hi = 0; }
+        if (hi) {
+          ++src;
+          hi = 0;
+        }
         unsigned len;
         uint32_t val;
         if (nanolog_varint_decode(src, &val, &len) != NANOLOG_RET_SUCCESS) {
-          return NANOLOG_RET_ERR_INVALID_PAYLOAD; }
+          return NANOLOG_RET_ERR_INVALID_PAYLOAD;
+        }
         prec = (int32_t)val;
         have_prec = 1;
         src += len;
@@ -278,21 +345,29 @@ nanolog_ret_t nanolog_parse_binary_log(nanolog_binary_field_handler_cb_t cb,
     }
 
     if ((type != NL_ARG_TYPE_PRECISION_STAR) &&
-        (type != NL_ARG_TYPE_STRING_PRECISION_LITERAL)) { have_prec = 0; }
+        (type != NL_ARG_TYPE_STRING_PRECISION_LITERAL)) {
+      have_prec = 0;
+    }
   } while (type != NL_ARG_TYPE_LOG_END);
 
-  if (buf_len) { cb(ctx, NL_ARG_TYPE_BUFFER, buf, buf_len); }
+  if (buf_len) {
+    cb(ctx, NL_ARG_TYPE_BUFFER, buf, buf_len);
+  }
   cb(ctx, NL_ARG_TYPE_LOG_END, NULL, 0);
   return NANOLOG_RET_SUCCESS;
 }
 
 nanolog_ret_t nanolog_varint_decode(void const *p, uint32_t *out_val, unsigned *out_len) {
-  if (!p || !out_val || !out_len) { return NANOLOG_RET_ERR_BAD_ARG; }
+  if (!p || !out_val || !out_len) {
+    return NANOLOG_RET_ERR_BAD_ARG;
+  }
   uint32_t val = 0;
   unsigned len = 1;
-  for (unsigned char const *src = (unsigned char const *)p; ; ++src, ++len) {
+  for (unsigned char const *src = (unsigned char const *)p;; ++src, ++len) {
     val = (val << 7) | (*src & 0x7F);
-    if (!(*src & 0x80)) { break; }
+    if (!(*src & 0x80)) {
+      break;
+    }
   }
   *out_val = val;
   *out_len = len;
@@ -303,16 +378,27 @@ nanolog_ret_t nanolog_varint_encode(uint32_t val,
                                     void *out_buf,
                                     unsigned buf_max,
                                     unsigned *out_len) {
-  if (!out_buf || !out_len || !buf_max) { return NANOLOG_RET_ERR_BAD_ARG; }
-  unsigned len = 0; { // precompute length and check that the encoding fits
+  if (!out_buf || !out_len || !buf_max) {
+    return NANOLOG_RET_ERR_BAD_ARG;
+  }
+  unsigned len = 0;
+  {  // precompute length and check that the encoding fits
     unsigned val_tmp = val;
-    do { ++len; val_tmp >>= 7; } while (val_tmp && (len <= buf_max));
-    if (len > buf_max) { return NANOLOG_RET_ERR_EXHAUSTED; }
+    do {
+      ++len;
+      val_tmp >>= 7;
+    } while (val_tmp && (len <= buf_max));
+    if (len > buf_max) {
+      return NANOLOG_RET_ERR_EXHAUSTED;
+    }
   }
 
   unsigned char *dst = (unsigned char *)out_buf;
   unsigned i = len;
-  do { dst[--i] = (unsigned char)(val | 0x80); val >>= 7; } while (val);
+  do {
+    dst[--i] = (unsigned char)(val | 0x80);
+    val >>= 7;
+  } while (val);
   dst[len - 1] &= 0x7F;
   *out_len = len;
   return NANOLOG_RET_SUCCESS;
@@ -320,7 +406,7 @@ nanolog_ret_t nanolog_varint_encode(uint32_t val,
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4146)
+#pragma warning(disable : 4146)
 #endif
 uint32_t nanolog_zigzag_encode(int32_t val) {
   return ((uint32_t)val << 1) ^ -((uint32_t)val >> 31);
@@ -351,4 +437,3 @@ _Static_assert(sizeof(unsigned long long) == 8, "");
 _Static_assert(sizeof(intmax_t) == 8, "");
 _Static_assert(sizeof(uintmax_t) == 8, "");
 #endif
-

--- a/nanolog.h
+++ b/nanolog.h
@@ -61,8 +61,8 @@ unsigned nanolog_get_threshold(void);
 
 typedef void (*nanolog_handler_cb_t)(void *ctx,
                                      unsigned sev,
-                                     void const *buf,  // nanolog_log_buf
-                                     unsigned buf_len, // nanolog_log_buf
+                                     void const *buf,   // nanolog_log_buf
+                                     unsigned buf_len,  // nanolog_log_buf
                                      char const *fmt,
                                      va_list args);
 
@@ -82,8 +82,8 @@ typedef void (*nanolog_binary_field_handler_cb_t)(void *ctx,
 nanolog_ret_t nanolog_parse_binary_log(nanolog_binary_field_handler_cb_t cb,
                                        void *ctx,
                                        unsigned sev,
-                                       void const *buf,  // nanolog_log_buf
-                                       unsigned buf_len, // nanolog_log_buf
+                                       void const *buf,   // nanolog_log_buf
+                                       unsigned buf_len,  // nanolog_log_buf
                                        char const *fmt,
                                        va_list args);
 
@@ -114,83 +114,95 @@ void nanolog_log_buf(unsigned sev,
 // Public logging macros
 
 #if NL_LOG_SEVERITY_THRESHOLD <= NL_SEV_DEBUG
-#define NL_LOG_DBG(FMT, ...) do { \
+#define NL_LOG_DBG(FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(DEBUG) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_debug(s_nanolog_fmt_str, ##__VA_ARGS__); \
-  } while(0)
-#define NL_LOG_DBG_CTX(CTX, FMT, ...) do { \
+  } while (0)
+#define NL_LOG_DBG_CTX(CTX, FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(DEBUG) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_debug_ctx(s_nanolog_fmt_str, (void *)(CTX), ##__VA_ARGS__); \
-  } while(0)
+  } while (0)
 #else
 #define NL_LOG_DBG(FMT, ...) (void)sizeof((FMT, ##__VA_ARGS__))
 #define NL_LOG_DBG_CTX(CTX, FMT, ...) (void)sizeof((FMT, CTX, ##__VA_ARGS__))
 #endif
 
 #if NL_LOG_SEVERITY_THRESHOLD <= NL_SEV_INFO
-#define NL_LOG_INF(FMT, ...) do { \
+#define NL_LOG_INF(FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(INFO) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_info(s_nanolog_fmt_str, ##__VA_ARGS__); \
-  } while(0)
-#define NL_LOG_INF_CTX(CTX, FMT, ...) do { \
+  } while (0)
+#define NL_LOG_INF_CTX(CTX, FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(INFO) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_info_ctx(s_nanolog_fmt_str, (void *)(CTX), ##__VA_ARGS__); \
-  } while(0)
+  } while (0)
 #else
 #define NL_LOG_INF(FMT, ...) (void)sizeof((FMT, ##__VA_ARGS__))
 #define NL_LOG_INF_CTX(CTX, FMT, ...) (void)sizeof((FMT, CTX, ##__VA_ARGS__))
 #endif
 
 #if NL_LOG_SEVERITY_THRESHOLD <= NL_SEV_WARNING
-#define NL_LOG_WRN(FMT, ...) do { \
+#define NL_LOG_WRN(FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(WARNING) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_warning(s_nanolog_fmt_str, ##__VA_ARGS__); \
-  } while(0)
-#define NL_LOG_WRN_CTX(CTX, FMT, ...) do { \
+  } while (0)
+#define NL_LOG_WRN_CTX(CTX, FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(WARNING) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_warning_ctx(s_nanolog_fmt_str, (void *)(CTX), ##__VA_ARGS__); \
-  } while(0)
+  } while (0)
 #else
 #define NL_LOG_WRN(FMT, ...) (void)sizeof((FMT, ##__VA_ARGS__))
 #define NL_LOG_WRN_CTX(CTX, FMT, ...) (void)sizeof((FMT, CTX, ##__VA_ARGS__))
 #endif
 
 #if NL_LOG_SEVERITY_THRESHOLD <= NL_SEV_ERROR
-#define NL_LOG_ERR(FMT, ...) do { \
+#define NL_LOG_ERR(FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(ERROR) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_error(s_nanolog_fmt_str, ##__VA_ARGS__); \
-  } while(0)
-#define NL_LOG_ERR_CTX(CTX, FMT, ...) do { \
+  } while (0)
+#define NL_LOG_ERR_CTX(CTX, FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(ERROR) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_error_ctx(s_nanolog_fmt_str, (void *)(CTX), ##__VA_ARGS__); \
-  } while(0)
+  } while (0)
 #else
 #define NL_LOG_ERR(FMT, ...) (void)sizeof((FMT, ##__VA_ARGS__))
 #define NL_LOG_ERR_CTX(CTX, FMT, ...) (void)sizeof((FMT, CTX, ##__VA_ARGS__))
 #endif
 
 #if NL_LOG_SEVERITY_THRESHOLD <= NL_SEV_CRITICAL
-#define NL_LOG_CRT(FMT, ...) do { \
+#define NL_LOG_CRT(FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(CRITICAL) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_critical(s_nanolog_fmt_str, ##__VA_ARGS__); \
-  } while(0)
-#define NL_LOG_CRT_CTX(CTX, FMT, ...) do { \
+  } while (0)
+#define NL_LOG_CRT_CTX(CTX, FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(CRITICAL) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_critical(s_nanolog_fmt_str, (void *)(CTX), ##__VA_ARGS__); \
-  } while(0)
+  } while (0)
 #else
 #define NL_LOG_CRT(FMT, ...) (void)sizeof((FMT, ##__VA_ARGS__))
 #define NL_LOG_CRT_CTX(CTX, FMT, ...) (void)sizeof((FMT, CTX, ##__VA_ARGS__))
 #endif
 
-#define NL_LOG_ASSERT(FMT, ...) do { \
+#define NL_LOG_ASSERT(FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(ASSERT) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_assert(s_nanolog_fmt_str, ##__VA_ARGS__); \
-  } while(0)
-#define NL_LOG_ASSERT_CTX(CTX, FMT, ...) do { \
+  } while (0)
+#define NL_LOG_ASSERT_CTX(CTX, FMT, ...) \
+  do { \
     static char const NL_ATTR_SEC(ASSERT) s_nanolog_fmt_str[] = FMT; \
     nanolog_log_assert_ctx(s_nanolog_fmt_str, (void *)(CTX), ##__VA_ARGS__); \
-  } while(0)
+  } while (0)
 
 #ifdef __GNUC__
 #define NL_LIKELY(COND) __builtin_expect(!!(COND), 1)
@@ -206,31 +218,36 @@ void nanolog_log_buf(unsigned sev,
 
 #ifdef NANOLOG_PROVIDE_ASSERT_MACROS
 
-#define NL_ASSERT(COND) do { \
+#define NL_ASSERT(COND) \
+  do { \
     if (NL_UNLIKELY(!(COND))) { \
       NL_LOG_ASSERT(__FILE__ "(" NL_STR(__LINE__) "): \"" #COND "\""); \
     } \
-  } while(0)
-#define NL_ASSERT_CTX(CTX, COND) do { \
+  } while (0)
+#define NL_ASSERT_CTX(CTX, COND) \
+  do { \
     if (NL_UNLIKELY(!(COND))) { \
       NL_LOG_ASSERT_CTX((CTX), __FILE__ "(" NL_STR(__LINE__) "): \"" #COND "\""); \
     } \
-  } while(0)
+  } while (0)
 
-#define NL_ASSERT_MSG(COND, FMT, ...) do { \
+#define NL_ASSERT_MSG(COND, FMT, ...) \
+  do { \
     if (NL_UNLIKELY(!(COND))) { \
-      NL_LOG_ASSERT(__FILE__ "(" NL_STR(__LINE__) "): \"" #COND "\" " FMT, ##__VA_ARGS__); \
+      NL_LOG_ASSERT(__FILE__ "(" NL_STR(__LINE__) "): \"" #COND "\" " FMT, \
+                    ##__VA_ARGS__); \
     } \
-  } while(0)
-#define NL_ASSERT_MSG_CTX(CTX, COND, FMT, ...) do { \
+  } while (0)
+#define NL_ASSERT_MSG_CTX(CTX, COND, FMT, ...) \
+  do { \
     if (NL_UNLIKELY(!(COND))) { \
       NL_LOG_ASSERT_CTX((CTX), \
-        __FILE__ "(" NL_STR(__LINE__) "): \"" #COND "\" " FMT, ##__VA_ARGS__); \
+                        __FILE__ "(" NL_STR(__LINE__) "): \"" #COND "\" " FMT, \
+                        ##__VA_ARGS__); \
     } \
-  } while(0)
+  } while (0)
 
-#define NL_ASSERT_FAIL() \
-  NL_LOG_ASSERT(__FILE__ "(" NL_STR(__LINE__) "): ASSERT FAIL")
+#define NL_ASSERT_FAIL() NL_LOG_ASSERT(__FILE__ "(" NL_STR(__LINE__) "): ASSERT FAIL")
 #define NL_ASSERT_FAIL_CTX(CTX) \
   NL_LOG_ASSERT_CTX((CTX), __FILE__ "(" NL_STR(__LINE__) "): ASSERT FAIL")
 
@@ -239,7 +256,7 @@ void nanolog_log_buf(unsigned sev,
 #define NL_ASSERT_FAIL_MSG_CTX(CTX, FMT, ...) \
   NL_LOG_ASSERT_CTX((CTX), __FILE__ "(" NL_STR(__LINE__) "): " FMT, ##__VA_ARGS__);
 
-#endif // NANOLOG_PROVIDE_ASSERT_MACROS
+#endif  // NANOLOG_PROVIDE_ASSERT_MACROS
 
 // Implementation details
 

--- a/tests/test_nanolog.cc
+++ b/tests/test_nanolog.cc
@@ -37,9 +37,9 @@ TEST_CASE("nanolog_get_threshold") {
 TEST_CASE("nanolog_set_handler") {
   static int s_calls{ 0 };
   REQUIRE(nanolog_set_handler(
-            [](void *, unsigned, void const *, unsigned, char const *, va_list) {
-              ++s_calls;
-            }) == NANOLOG_RET_SUCCESS);
+              [](void *, unsigned, void const *, unsigned, char const *, va_list) {
+                ++s_calls;
+              }) == NANOLOG_RET_SUCCESS);
   nanolog_log_sev(NL_SEV_ASSERT, "");
   REQUIRE(s_calls == 1);
 }
@@ -86,10 +86,10 @@ TEST_CASE("nanolog_log_sev") {
   s_fmt = &fmt;
   static unsigned s_sev{ 12345 };
   REQUIRE(nanolog_set_handler(
-            [](void *, unsigned sev, void const *, unsigned, char const *fmt_, va_list) {
-              *s_fmt = fmt_;
-              s_sev = sev;
-            }) == NANOLOG_RET_SUCCESS);
+              [](void *, unsigned sev, void const *, unsigned, char const *fmt_, va_list) {
+                *s_fmt = fmt_;
+                s_sev = sev;
+              }) == NANOLOG_RET_SUCCESS);
   nanolog_log_sev(NL_SEV_WARNING, "logging is fun");
   REQUIRE(fmt == "logging is fun");
   REQUIRE_EQ(s_sev, NL_SEV_WARNING | NL_DYNAMIC_SEV_BIT);
@@ -101,11 +101,12 @@ TEST_CASE("nanolog_log_sev_ctx") {
     unsigned sev;
   };
   std::vector<Log> captures;
-  REQUIRE(nanolog_set_handler(
-            [](void *ctx, unsigned sev, void const *, unsigned, char const *fmt, va_list) {
-              static_cast<std::vector<Log> *>(ctx)->emplace_back(
+  REQUIRE(
+      nanolog_set_handler(
+          [](void *ctx, unsigned sev, void const *, unsigned, char const *fmt, va_list) {
+            static_cast<std::vector<Log> *>(ctx)->emplace_back(
                 Log{ .fmt = fmt, .sev = sev });
-            }) == NANOLOG_RET_SUCCESS);
+          }) == NANOLOG_RET_SUCCESS);
 
   SUBCASE("marks severity as dynamic") {
     nanolog_log_sev_ctx(NL_SEV_ERROR, &captures, "hello");
@@ -325,17 +326,17 @@ TEST_CASE("nanolog_parse_binary_log") {
     REQUIRE(nanolog_fmt_is_binary(fmt, &binary) == NANOLOG_RET_SUCCESS);
     REQUIRE(binary == 1);
     REQUIRE(nanolog_parse_binary_log(
-              [](void *ctx_, nl_arg_type_t type, void const *p, unsigned len) {
-                auto const *pc{ static_cast<unsigned char const *>(p) };
-                static_cast<std::vector<BinaryLog> *>(ctx_)->emplace_back(
-                  BinaryLog{ .type = type, .payload = byte_vec(pc, pc + len) });
-              },
-              ctx,
-              sev,
-              buf,
-              buf_len,
-              fmt,
-              args) == NANOLOG_RET_SUCCESS);
+                [](void *ctx_, nl_arg_type_t type, void const *p, unsigned len) {
+                  auto const *pc{ static_cast<unsigned char const *>(p) };
+                  static_cast<std::vector<BinaryLog> *>(ctx_)->emplace_back(
+                      BinaryLog{ .type = type, .payload = byte_vec(pc, pc + len) });
+                },
+                ctx,
+                sev,
+                buf,
+                buf_len,
+                fmt,
+                args) == NANOLOG_RET_SUCCESS);
   });
 
   std::vector<BinaryLog> logs;
@@ -567,7 +568,7 @@ TEST_CASE("nanolog_parse_binary_log") {
   }
 
   SUBCASE("buffer") {
-    char const bin_buf[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    char const bin_buf[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
     nanolog_log_buf(NL_SEV_DEBUG,
                     &logs,
                     bin_buf,

--- a/tests/test_nanolog.cc
+++ b/tests/test_nanolog.cc
@@ -35,16 +35,17 @@ TEST_CASE("nanolog_get_threshold") {
 }
 
 TEST_CASE("nanolog_set_handler") {
-  static int s_calls{0};
-  REQUIRE(nanolog_set_handler([](void *, unsigned, void const *, unsigned,
-                                 char const *, va_list) { ++s_calls; }) ==
-          NANOLOG_RET_SUCCESS);
+  static int s_calls{ 0 };
+  REQUIRE(nanolog_set_handler(
+            [](void *, unsigned, void const *, unsigned, char const *, va_list) {
+              ++s_calls;
+            }) == NANOLOG_RET_SUCCESS);
   nanolog_log_sev(NL_SEV_ASSERT, "");
   REQUIRE(s_calls == 1);
 }
 
 TEST_CASE("nanolog_fmt_is_binary") {
-  int binary{9999};
+  int binary{ 9999 };
   REQUIRE(nanolog_fmt_is_binary(nullptr, nullptr) == NANOLOG_RET_ERR_BAD_ARG);
   REQUIRE(nanolog_fmt_is_binary(nullptr, &binary) == NANOLOG_RET_ERR_BAD_ARG);
   REQUIRE(nanolog_fmt_is_binary("hello", nullptr) == NANOLOG_RET_ERR_BAD_ARG);
@@ -83,12 +84,12 @@ TEST_CASE("nanolog_log_sev") {
   static std::string *s_fmt;
   std::string fmt;
   s_fmt = &fmt;
-  static unsigned s_sev{12345};
-  REQUIRE(nanolog_set_handler([](void *, unsigned sev, void const *, unsigned,
-                                 char const *fmt_, va_list) {
-            *s_fmt = fmt_;
-            s_sev = sev;
-          }) == NANOLOG_RET_SUCCESS);
+  static unsigned s_sev{ 12345 };
+  REQUIRE(nanolog_set_handler(
+            [](void *, unsigned sev, void const *, unsigned, char const *fmt_, va_list) {
+              *s_fmt = fmt_;
+              s_sev = sev;
+            }) == NANOLOG_RET_SUCCESS);
   nanolog_log_sev(NL_SEV_WARNING, "logging is fun");
   REQUIRE(fmt == "logging is fun");
   REQUIRE_EQ(s_sev, NL_SEV_WARNING | NL_DYNAMIC_SEV_BIT);
@@ -100,11 +101,11 @@ TEST_CASE("nanolog_log_sev_ctx") {
     unsigned sev;
   };
   std::vector<Log> captures;
-  REQUIRE(nanolog_set_handler([](void *ctx, unsigned sev, void const *,
-                                 unsigned, char const *fmt, va_list) {
-            static_cast<std::vector<Log> *>(ctx)->emplace_back(
-                Log{.fmt = fmt, .sev = sev});
-          }) == NANOLOG_RET_SUCCESS);
+  REQUIRE(nanolog_set_handler(
+            [](void *ctx, unsigned sev, void const *, unsigned, char const *fmt, va_list) {
+              static_cast<std::vector<Log> *>(ctx)->emplace_back(
+                Log{ .fmt = fmt, .sev = sev });
+            }) == NANOLOG_RET_SUCCESS);
 
   SUBCASE("marks severity as dynamic") {
     nanolog_log_sev_ctx(NL_SEV_ERROR, &captures, "hello");
@@ -119,53 +120,49 @@ TEST_CASE("nanolog_varint_decode") {
 
   SUBCASE("bad args") {
     unsigned char c;
-    REQUIRE(nanolog_varint_decode(nullptr, nullptr, nullptr) ==
-            NANOLOG_RET_ERR_BAD_ARG);
-    REQUIRE(nanolog_varint_decode(nullptr, nullptr, &len) ==
-            NANOLOG_RET_ERR_BAD_ARG);
-    REQUIRE(nanolog_varint_decode(nullptr, &val, nullptr) ==
-            NANOLOG_RET_ERR_BAD_ARG);
-    REQUIRE(nanolog_varint_decode(&c, nullptr, nullptr) ==
-            NANOLOG_RET_ERR_BAD_ARG);
+    REQUIRE(nanolog_varint_decode(nullptr, nullptr, nullptr) == NANOLOG_RET_ERR_BAD_ARG);
+    REQUIRE(nanolog_varint_decode(nullptr, nullptr, &len) == NANOLOG_RET_ERR_BAD_ARG);
+    REQUIRE(nanolog_varint_decode(nullptr, &val, nullptr) == NANOLOG_RET_ERR_BAD_ARG);
+    REQUIRE(nanolog_varint_decode(&c, nullptr, nullptr) == NANOLOG_RET_ERR_BAD_ARG);
   }
 
   SUBCASE("zero") {
-    unsigned char const buf[] = {0};
+    unsigned char const buf[] = { 0 };
     REQUIRE(nanolog_varint_decode(buf, &val, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(val == 0);
     REQUIRE(len == 1);
   }
 
   SUBCASE("stops at first byte that doesn't have high bit set") {
-    unsigned char const buf[] = {0x01, 0xFF};
+    unsigned char const buf[] = { 0x01, 0xFF };
     REQUIRE(nanolog_varint_decode(buf, &val, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(val == 1);
     REQUIRE(len == 1);
   }
 
   SUBCASE("one byte less than 127") {
-    unsigned char const buf[] = {79};
+    unsigned char const buf[] = { 79 };
     REQUIRE(nanolog_varint_decode(buf, &val, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(val == 79);
     REQUIRE(len == 1);
   }
 
   SUBCASE("127 is the largest single-byte value") {
-    unsigned char const buf[] = {0x7F};
+    unsigned char const buf[] = { 0x7F };
     REQUIRE(nanolog_varint_decode(buf, &val, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(val == 127);
     REQUIRE(len == 1);
   }
 
   SUBCASE("128 is the smallest two-byte value") {
-    unsigned char const buf[] = {0x81, 0x00};
+    unsigned char const buf[] = { 0x81, 0x00 };
     REQUIRE(nanolog_varint_decode(buf, &val, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(val == 128);
     REQUIRE(len == 2);
   }
 
   SUBCASE("two bytes greater than 128") {
-    unsigned char const buf[] = {0xAA, 0x45};
+    unsigned char const buf[] = { 0xAA, 0x45 };
     REQUIRE(nanolog_varint_decode(buf, &val, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(val == 5445);
     REQUIRE(len == 2);
@@ -174,29 +171,23 @@ TEST_CASE("nanolog_varint_decode") {
 
 TEST_CASE("nanolog_varint_encode") {
   byte buf[16];
-  size_t const bufsz{sizeof(buf)};
+  size_t const bufsz{ sizeof(buf) };
   memset(buf, 0, sizeof(buf));
-  auto len{0u};
+  auto len{ 0u };
 
   SUBCASE("bad args") {
-    REQUIRE(nanolog_varint_encode(0, nullptr, 0, nullptr) ==
-            NANOLOG_RET_ERR_BAD_ARG);
-    REQUIRE(nanolog_varint_encode(0, buf, 0, nullptr) ==
-            NANOLOG_RET_ERR_BAD_ARG);
+    REQUIRE(nanolog_varint_encode(0, nullptr, 0, nullptr) == NANOLOG_RET_ERR_BAD_ARG);
+    REQUIRE(nanolog_varint_encode(0, buf, 0, nullptr) == NANOLOG_RET_ERR_BAD_ARG);
     REQUIRE(nanolog_varint_encode(0, buf, sizeof(buf), nullptr) ==
             NANOLOG_RET_ERR_BAD_ARG);
     REQUIRE(nanolog_varint_encode(0, buf, 0, &len) == NANOLOG_RET_ERR_BAD_ARG);
   }
 
   SUBCASE("exhaustion") {
-    REQUIRE(nanolog_varint_encode(1u << 7, buf, 1, &len) ==
-            NANOLOG_RET_ERR_EXHAUSTED);
-    REQUIRE(nanolog_varint_encode(1u << 14, buf, 2, &len) ==
-            NANOLOG_RET_ERR_EXHAUSTED);
-    REQUIRE(nanolog_varint_encode(1u << 21, buf, 3, &len) ==
-            NANOLOG_RET_ERR_EXHAUSTED);
-    REQUIRE(nanolog_varint_encode(1u << 28, buf, 4, &len) ==
-            NANOLOG_RET_ERR_EXHAUSTED);
+    REQUIRE(nanolog_varint_encode(1u << 7, buf, 1, &len) == NANOLOG_RET_ERR_EXHAUSTED);
+    REQUIRE(nanolog_varint_encode(1u << 14, buf, 2, &len) == NANOLOG_RET_ERR_EXHAUSTED);
+    REQUIRE(nanolog_varint_encode(1u << 21, buf, 3, &len) == NANOLOG_RET_ERR_EXHAUSTED);
+    REQUIRE(nanolog_varint_encode(1u << 28, buf, 4, &len) == NANOLOG_RET_ERR_EXHAUSTED);
   }
 
   buf[0] = buf[1] = 0xFF;
@@ -214,27 +205,24 @@ TEST_CASE("nanolog_varint_encode") {
   }
 
   SUBCASE("single-byte values") {
-    for (auto i{0u}; i < 127; ++i) {
+    for (auto i{ 0u }; i < 127; ++i) {
       buf[0] = 0xFF;
       len = 0;
-      REQUIRE(nanolog_varint_encode(i, buf, bufsz, &len) ==
-              NANOLOG_RET_SUCCESS);
+      REQUIRE(nanolog_varint_encode(i, buf, bufsz, &len) == NANOLOG_RET_SUCCESS);
       REQUIRE(len == 1);
       REQUIRE(buf[0] == i);
     }
   }
 
   SUBCASE("128 is the smallest two-byte encoding") {
-    REQUIRE(nanolog_varint_encode(128, buf, bufsz, &len) ==
-            NANOLOG_RET_SUCCESS);
+    REQUIRE(nanolog_varint_encode(128, buf, bufsz, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(len == 2);
     REQUIRE(buf[0] == 0x81);
     REQUIRE(buf[1] == 0);
   }
 
   SUBCASE("two bytes greater than 128") {
-    REQUIRE(nanolog_varint_encode(5445, buf, bufsz, &len) ==
-            NANOLOG_RET_SUCCESS);
+    REQUIRE(nanolog_varint_encode(5445, buf, bufsz, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(len == 2);
     REQUIRE(buf[0] == 0xAA);
     REQUIRE(buf[1] == 0x45);
@@ -244,9 +232,8 @@ TEST_CASE("nanolog_varint_encode") {
 TEST_CASE("varint round-trip") {
   byte buf[16];
   unsigned len, val;
-  for (auto i{0u}; i < 65536u; ++i) {
-    REQUIRE(nanolog_varint_encode(i, buf, sizeof(buf), &len) ==
-            NANOLOG_RET_SUCCESS);
+  for (auto i{ 0u }; i < 65536u; ++i) {
+    REQUIRE(nanolog_varint_encode(i, buf, sizeof(buf), &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(nanolog_varint_decode(buf, &val, &len) == NANOLOG_RET_SUCCESS);
     REQUIRE(val == i);
   }
@@ -270,7 +257,7 @@ TEST_CASE("zigzag") {
   }
 
   SUBCASE("round-trip") {
-    for (auto i{-65535}; i < 65536; ++i) {
+    for (auto i{ -65535 }; i < 65536; ++i) {
       REQUIRE(nanolog_zigzag_decode(nanolog_zigzag_encode(i)) == i);
     }
   }
@@ -279,8 +266,7 @@ TEST_CASE("zigzag") {
 namespace {
 void require_varint(void const *payload, unsigned expected_val) {
   unsigned actual_val, len;
-  REQUIRE(nanolog_varint_decode(payload, &actual_val, &len) ==
-          NANOLOG_RET_SUCCESS);
+  REQUIRE(nanolog_varint_decode(payload, &actual_val, &len) == NANOLOG_RET_SUCCESS);
   REQUIRE(actual_val == expected_val);
 }
 
@@ -319,30 +305,37 @@ struct BinaryLog {
   byte_vec payload;
 };
 
-char const *make_bin_payload(char const *fmt, unsigned guid,
-                             byte_vec &storage) {
+char const *make_bin_payload(char const *fmt, unsigned guid, byte_vec &storage) {
   storage.clear();
   emit_bin_fmt_str(fmt, guid, storage);
   return reinterpret_cast<char const *>(storage.data());
 }
-} // namespace
+}  // namespace
 
 TEST_CASE("nanolog_parse_binary_log") {
-  nanolog_handler_cb_t const old_handler{nanolog_get_handler()};
+  nanolog_handler_cb_t const old_handler{ nanolog_get_handler() };
 
-  nanolog_set_handler([](void *ctx, unsigned sev, void const *buf,
-                         unsigned buf_len, char const *fmt, va_list args) {
+  nanolog_set_handler([](void *ctx,
+                         unsigned sev,
+                         void const *buf,
+                         unsigned buf_len,
+                         char const *fmt,
+                         va_list args) {
     int binary;
     REQUIRE(nanolog_fmt_is_binary(fmt, &binary) == NANOLOG_RET_SUCCESS);
     REQUIRE(binary == 1);
-    REQUIRE(
-        nanolog_parse_binary_log(
-            [](void *ctx_, nl_arg_type_t type, void const *p, unsigned len) {
-              auto const *pc{static_cast<unsigned char const *>(p)};
-              static_cast<std::vector<BinaryLog> *>(ctx_)->emplace_back(
-                  BinaryLog{.type = type, .payload = byte_vec(pc, pc + len)});
-            },
-            ctx, sev, buf, buf_len, fmt, args) == NANOLOG_RET_SUCCESS);
+    REQUIRE(nanolog_parse_binary_log(
+              [](void *ctx_, nl_arg_type_t type, void const *p, unsigned len) {
+                auto const *pc{ static_cast<unsigned char const *>(p) };
+                static_cast<std::vector<BinaryLog> *>(ctx_)->emplace_back(
+                  BinaryLog{ .type = type, .payload = byte_vec(pc, pc + len) });
+              },
+              ctx,
+              sev,
+              buf,
+              buf_len,
+              fmt,
+              args) == NANOLOG_RET_SUCCESS);
   });
 
   std::vector<BinaryLog> logs;
@@ -394,8 +387,7 @@ TEST_CASE("nanolog_parse_binary_log") {
   }
 
   SUBCASE("8-byte scalar") {
-    nanolog_log_debug_ctx(make_bin_payload("%llu", 0, buf), &logs,
-                          0x12345678abcdef12);
+    nanolog_log_debug_ctx(make_bin_payload("%llu", 0, buf), &logs, 0x12345678abcdef12);
     REQUIRE(logs.size() == 4);
     REQUIRE(logs[0].type == NL_ARG_TYPE_LOG_START);
     REQUIRE(logs[1].type == NL_ARG_TYPE_GUID);
@@ -436,14 +428,14 @@ TEST_CASE("nanolog_parse_binary_log") {
     REQUIRE(logs[2].type == NL_ARG_TYPE_WINT_T);
     REQUIRE(logs[2].payload.size() == sizeof(wint_t));
     switch (sizeof(wint_t)) {
-    case 2:
-      require_2byte(logs[2].payload.data(), 1234);
-      break;
-    case 4:
-      require_4byte(logs[2].payload.data(), 1234);
-      break;
-    default:
-      REQUIRE_MESSAGE(0, "unsupported size of wint_t: ", sizeof(wint_t));
+      case 2:
+        require_2byte(logs[2].payload.data(), 1234);
+        break;
+      case 4:
+        require_4byte(logs[2].payload.data(), 1234);
+        break;
+      default:
+        REQUIRE_MESSAGE(0, "unsupported size of wint_t: ", sizeof(wint_t));
     }
     REQUIRE(logs[3].type == NL_ARG_TYPE_LOG_END);
   }
@@ -497,9 +489,8 @@ TEST_CASE("nanolog_parse_binary_log") {
       REQUIRE(logs[2].type == NL_ARG_TYPE_STRING_LEN);
       require_varint(logs[2].payload.data(), unsigned(strlen("hello world")));
       REQUIRE(logs[3].type == NL_ARG_TYPE_STRING);
-      REQUIRE(
-          std::string{reinterpret_cast<char const *>(logs[3].payload.data()),
-                      unsigned(logs[3].payload.size())} == "hello world");
+      REQUIRE(std::string{ reinterpret_cast<char const *>(logs[3].payload.data()),
+                           unsigned(logs[3].payload.size()) } == "hello world");
       REQUIRE(logs[4].type == NL_ARG_TYPE_LOG_END);
     }
 
@@ -513,9 +504,8 @@ TEST_CASE("nanolog_parse_binary_log") {
       REQUIRE(logs[3].type == NL_ARG_TYPE_STRING_LEN);
       require_varint(logs[3].payload.data(), unsigned(strlen("hello world")));
       REQUIRE(logs[4].type == NL_ARG_TYPE_STRING);
-      REQUIRE(
-          std::string{reinterpret_cast<char const *>(logs[4].payload.data()),
-                      unsigned(logs[4].payload.size())} == "hello world");
+      REQUIRE(std::string{ reinterpret_cast<char const *>(logs[4].payload.data()),
+                           unsigned(logs[4].payload.size()) } == "hello world");
       REQUIRE(logs[5].type == NL_ARG_TYPE_LOG_END);
     }
 
@@ -529,9 +519,8 @@ TEST_CASE("nanolog_parse_binary_log") {
       REQUIRE(logs[3].type == NL_ARG_TYPE_STRING_LEN);
       require_varint(logs[3].payload.data(), 5);
       REQUIRE(logs[4].type == NL_ARG_TYPE_STRING);
-      REQUIRE(
-          std::string{reinterpret_cast<char const *>(logs[4].payload.data()),
-                      unsigned(logs[4].payload.size())} == "hello");
+      REQUIRE(std::string{ reinterpret_cast<char const *>(logs[4].payload.data()),
+                           unsigned(logs[4].payload.size()) } == "hello");
       REQUIRE(logs[5].type == NL_ARG_TYPE_LOG_END);
     }
 
@@ -545,9 +534,8 @@ TEST_CASE("nanolog_parse_binary_log") {
       REQUIRE(logs[3].type == NL_ARG_TYPE_STRING_LEN);
       require_varint(logs[3].payload.data(), unsigned(strlen("hello world")));
       REQUIRE(logs[4].type == NL_ARG_TYPE_STRING);
-      REQUIRE(
-          std::string{reinterpret_cast<char const *>(logs[4].payload.data()),
-                      unsigned(logs[4].payload.size())} == "hello world");
+      REQUIRE(std::string{ reinterpret_cast<char const *>(logs[4].payload.data()),
+                           unsigned(logs[4].payload.size()) } == "hello world");
       REQUIRE(logs[5].type == NL_ARG_TYPE_LOG_END);
     }
 
@@ -559,9 +547,8 @@ TEST_CASE("nanolog_parse_binary_log") {
       REQUIRE(logs[2].type == NL_ARG_TYPE_STRING_LEN);
       require_varint(logs[2].payload.data(), unsigned(strlen("hello world")));
       REQUIRE(logs[3].type == NL_ARG_TYPE_STRING);
-      REQUIRE(
-          std::string{reinterpret_cast<char const *>(logs[3].payload.data()),
-                      unsigned(logs[3].payload.size())} == "hello world");
+      REQUIRE(std::string{ reinterpret_cast<char const *>(logs[3].payload.data()),
+                           unsigned(logs[3].payload.size()) } == "hello world");
       REQUIRE(logs[4].type == NL_ARG_TYPE_LOG_END);
     }
 
@@ -573,30 +560,39 @@ TEST_CASE("nanolog_parse_binary_log") {
       REQUIRE(logs[2].type == NL_ARG_TYPE_STRING_LEN);
       require_varint(logs[2].payload.data(), 4);
       REQUIRE(logs[3].type == NL_ARG_TYPE_STRING);
-      REQUIRE(
-          std::string{reinterpret_cast<char const *>(logs[3].payload.data()),
-                      unsigned(logs[3].payload.size())} == "hell");
+      REQUIRE(std::string{ reinterpret_cast<char const *>(logs[3].payload.data()),
+                           unsigned(logs[3].payload.size()) } == "hell");
       REQUIRE(logs[4].type == NL_ARG_TYPE_LOG_END);
     }
   }
 
   SUBCASE("buffer") {
-    char const bin_buf[16] = {1, 2,  3,  4,  5,  6,  7,  8,
-                              9, 10, 11, 12, 13, 14, 15, 16};
-    nanolog_log_buf(NL_SEV_DEBUG, &logs, bin_buf, sizeof(bin_buf),
+    char const bin_buf[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    nanolog_log_buf(NL_SEV_DEBUG,
+                    &logs,
+                    bin_buf,
+                    sizeof(bin_buf),
                     make_bin_payload("", 0, buf));
     REQUIRE(logs.size() == 5);
     REQUIRE(logs[0].type == NL_ARG_TYPE_LOG_START);
     REQUIRE(logs[1].type == NL_ARG_TYPE_GUID);
     REQUIRE(logs[2].type == NL_ARG_TYPE_DYNAMIC_SEVERITY);
     REQUIRE(logs[3].type == NL_ARG_TYPE_BUFFER);
-    REQUIRE(logs[3].payload == byte_vec{bin_buf, bin_buf + sizeof(bin_buf)});
+    REQUIRE(logs[3].payload == byte_vec{ bin_buf, bin_buf + sizeof(bin_buf) });
     REQUIRE(logs[4].type == NL_ARG_TYPE_LOG_END);
   }
 
   SUBCASE("large full string") {
     nanolog_log_debug_ctx(make_bin_payload("abc %*.*d def %*.*u ghi %.2s %f", 6789, buf),
-        &logs, 123, 456, 100, 789, 222, 200, "hello world", 3.141);
+                          &logs,
+                          123,
+                          456,
+                          100,
+                          789,
+                          222,
+                          200,
+                          "hello world",
+                          3.141);
     REQUIRE(logs.size() == 12);
     REQUIRE(logs[0].type == NL_ARG_TYPE_LOG_START);
     REQUIRE(logs[1].type == NL_ARG_TYPE_GUID);
@@ -616,8 +612,8 @@ TEST_CASE("nanolog_parse_binary_log") {
     REQUIRE(logs[8].type == NL_ARG_TYPE_STRING_LEN);
     require_varint(logs[8].payload.data(), 2);
     REQUIRE(logs[9].type == NL_ARG_TYPE_STRING);
-    REQUIRE(std::string{reinterpret_cast<char const *>(logs[9].payload.data()),
-                        unsigned(logs[3].payload.size())} == "he");
+    REQUIRE(std::string{ reinterpret_cast<char const *>(logs[9].payload.data()),
+                         unsigned(logs[3].payload.size()) } == "he");
     REQUIRE(logs[10].type == NL_ARG_TYPE_DOUBLE);
     require_double(logs[10].payload.data(), 3.141);
     REQUIRE(logs[11].type == NL_ARG_TYPE_LOG_END);

--- a/unclog/args.cc
+++ b/unclog/args.cc
@@ -2,13 +2,14 @@
 
 namespace {
 void print_usage() {
-  NL_LOG_INF("Usage: unclog <input-file> "
-             "<-o output-elf> "
-             "<-j output-json> "
-             "[-v|-vv] "
-             "[--noreturn-func foo]\n");
+  NL_LOG_INF(
+      "Usage: unclog <input-file> "
+      "<-o output-elf> "
+      "<-j output-json> "
+      "[-v|-vv] "
+      "[--noreturn-func foo]\n");
 }
-}
+}  // namespace
 
 enum next_token {
   ANYTHING,
@@ -17,12 +18,14 @@ enum next_token {
   NORETURN_FUNC,
 };
 
-bool args_parse(char const *argv[], int const argc, args& out_args) {
-  bool ok{true};
-  next_token nt{ANYTHING};
+bool args_parse(char const* argv[], int const argc, args& out_args) {
+  bool ok{ true };
+  next_token nt{ ANYTHING };
 
-  for (int i{1}; i < argc; ++i) {
-    if (!ok) { break; }
+  for (int i{ 1 }; i < argc; ++i) {
+    if (!ok) {
+      break;
+    }
 
     switch (nt) {
       case OUTPUT_ELF:
@@ -36,20 +39,29 @@ bool args_parse(char const *argv[], int const argc, args& out_args) {
         break;
 
       case NORETURN_FUNC:
-        if (argv[i][0] == '-') { ok = false; break; }
+        if (argv[i][0] == '-') {
+          ok = false;
+          break;
+        }
         out_args.noreturn_funcs.push_back(argv[i]);
         nt = ANYTHING;
         break;
 
       case ANYTHING:
         if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output-elf")) {
-          if (out_args.output_elf) { ok = false; break; }
+          if (out_args.output_elf) {
+            ok = false;
+            break;
+          }
           nt = OUTPUT_ELF;
           break;
         }
 
         if (!strcmp(argv[i], "-j") || !strcmp(argv[i], "--output-json")) {
-          if (out_args.output_json) { ok = false; break; }
+          if (out_args.output_json) {
+            ok = false;
+            break;
+          }
           nt = OUTPUT_JSON;
           break;
         }
@@ -77,7 +89,10 @@ bool args_parse(char const *argv[], int const argc, args& out_args) {
           break;
         }
 
-        if ((argv[i][0] == '-') || out_args.input_elf) { ok = false; break; }
+        if ((argv[i][0] == '-') || out_args.input_elf) {
+          ok = false;
+          break;
+        }
         out_args.input_elf = argv[i];
         break;
     }
@@ -86,6 +101,8 @@ bool args_parse(char const *argv[], int const argc, args& out_args) {
   ok = ok && (nt == ANYTHING) && out_args.input_elf && out_args.output_elf &&
        out_args.output_json;
 
-  if (!ok) { print_usage(); }
+  if (!ok) {
+    print_usage();
+  }
   return ok;
 }

--- a/unclog/args.h
+++ b/unclog/args.h
@@ -9,4 +9,4 @@ struct args {
   std::vector<char const *> noreturn_funcs;
 };
 
-bool args_parse(char const *argv[], int const argc, args& out_args);
+bool args_parse(char const *argv[], int const argc, args &out_args);

--- a/unclog/boilerplate.h
+++ b/unclog/boilerplate.h
@@ -13,7 +13,10 @@
 #include <unordered_set>
 #include <vector>
 
-template <typename ...Args> void unused(Args&& ...args) { (void)sizeof...(args); }
+template <typename... Args>
+void unused(Args &&...args) {
+  (void)sizeof...(args);
+}
 
 using i8 = int8_t;
 using u8 = uint8_t;
@@ -36,7 +39,7 @@ struct aligned_deleter {
 #endif
   }
 };
-}
+}  // namespace detail
 
 using byte_vec = std::vector<byte>;
 using bytes_ptr = std::unique_ptr<byte[], detail::aligned_deleter>;
@@ -44,7 +47,7 @@ using file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
 
 inline file_ptr open_file(char const *fn, char const *mode) {
   auto file_ptr_close = [](FILE *fp) { return fp ? std::fclose(fp) : 0; };
-  return file_ptr{std::fopen(fn, mode), file_ptr_close};
+  return file_ptr{ std::fopen(fn, mode), file_ptr_close };
 }
 
 inline bytes_ptr alloc_bytes(unsigned align, unsigned len) {
@@ -52,9 +55,11 @@ inline bytes_ptr alloc_bytes(unsigned align, unsigned len) {
 #ifdef _MSC_VER
   mem = _aligned_malloc(len, align);
 #else
-  if (posix_memalign(&mem, align, len)) { mem = nullptr; }
+  if (posix_memalign(&mem, align, len)) {
+    mem = nullptr;
+  }
 #endif
-  return bytes_ptr{static_cast<byte *>(mem)};
+  return bytes_ptr{ static_cast<byte *>(mem) };
 }
 
 enum { UNCLOG_SEV_DYNAMIC = 1000 };

--- a/unclog/elf.h
+++ b/unclog/elf.h
@@ -179,7 +179,7 @@ struct elf {
   char const *strtab;
 };
 
-bool nl_elf_load(elf& e, char const *filename);
+bool nl_elf_load(elf &e, char const *filename);
 
 void nl_elf_print(elf_osabi eo);
 void nl_elf_print(elf_type et);
@@ -187,8 +187,7 @@ void nl_elf_print(elf_sec_type est);
 void nl_elf_print(elf_sec_flags esf);
 void nl_elf_print(elf_sym_bind esb);
 void nl_elf_print(elf_sym_type est);
-void nl_elf_print(elf_hdr32 const& h);
-void nl_elf_print(elf_prog_hdr32 const& p);
-void nl_elf_print(elf_section_hdr32 const& s, char const *sec_names);
-void nl_elf_print(elf_symbol32 const& s, char const *strtab);
-
+void nl_elf_print(elf_hdr32 const &h);
+void nl_elf_print(elf_prog_hdr32 const &p);
+void nl_elf_print(elf_section_hdr32 const &s, char const *sec_names);
+void nl_elf_print(elf_symbol32 const &s, char const *strtab);

--- a/unclog/emit.h
+++ b/unclog/emit.h
@@ -2,11 +2,11 @@
 
 #include "boilerplate.h"
 
-void emit_bin_fmt_str(char const *str, unsigned guid, byte_vec& fmt_bin_mem);
-void emit_bin_fmt_strs(std::vector<char const *> const& fmt_strs,
+void emit_bin_fmt_str(char const* str, unsigned guid, byte_vec& fmt_bin_mem);
+void emit_bin_fmt_strs(std::vector<char const*> const& fmt_strs,
                        u32_vec& fmt_bin_addrs,
                        byte_vec& fmt_bin_mem);
 
-bool emit_json_manifest(std::vector<char const *> const& fmt_strs,
+bool emit_json_manifest(std::vector<char const*> const& fmt_strs,
                         std::vector<u8> const& fmt_str_sevs,
-                        char const *json_filename);
+                        char const* json_filename);

--- a/unclog/thumb2.cc
+++ b/unclog/thumb2.cc
@@ -1,6 +1,6 @@
 #include "thumb2.h"
-#include "thumb2_inst.h"
 #include "elf.h"
+#include "thumb2_inst.h"
 
 #include <stack>
 #include <unordered_map>
@@ -15,16 +15,6 @@ struct reg_state {
   u16 cmp_imm_present = 0;
 };
 
-//void print(reg_state const& rs) {
-//  NL_LOG_DBG("k=0x%04hx ", rs.known);
-//  for (auto i = 0u; i < 16; ++i) {
-//    if ((rs.known >> i) & 1) {
-//      NL_LOG_DBG("R%u=%x ", unsigned(i), rs.regs[i]);
-//    }
-//  }
-//  NL_LOG_DBG("\n");
-//}
-
 struct path_state {
   reg_state rs;
   u8 it_flags, it_rem;
@@ -38,12 +28,12 @@ struct func_state {
              elf const& e_,
              elf_section_hdr32 const& s,
              func_log_call_analysis& lca_)
-    : f(f_)
-    , func_start{f_.st_value & ~1u}
-    , func_end{func_start + f.st_size}
-    , func_ofs{s.sh_offset + func_start - s.sh_addr}
-    , e(e_)
-    , lca(lca_) {
+      : f(f_),
+        func_start{ f_.st_value & ~1u },
+        func_end{ func_start + f.st_size },
+        func_ofs{ s.sh_offset + func_start - s.sh_addr },
+        e(e_),
+        lca(lca_) {
     discovered_log_strs.reserve(32);
   }
 
@@ -57,13 +47,13 @@ struct func_state {
 };
 
 path_state path_state_branch(path_state const& p, u32 label) {
-  path_state b{p};
+  path_state b{ p };
   b.rs.regs[reg::PC] = label;
   return b;
 }
 
 path_state path_state_it(path_state const& p) {
-  path_state b{p};
+  path_state b{ p };
   b.it_flags = ~b.it_flags;
   return b;
 }
@@ -72,16 +62,22 @@ bool address_in_func(u32 addr, func_state const& s) {
   return (addr >= s.func_start) && (!s.f.st_size || (addr < s.func_end));
 }
 
-bool reg_test_known(u16 regs, int idx) { return regs & (1u << idx); }
-void reg_mark_known(u16& regs, int idx) { regs |= (1u << idx); }
-void reg_clear_known(u16& regs, int idx) { regs &= u16(~(1u << idx)); }
+bool reg_test_known(u16 regs, int idx) {
+  return regs & (1u << idx);
+}
+void reg_mark_known(u16& regs, int idx) {
+  regs |= (1u << idx);
+}
+void reg_clear_known(u16& regs, int idx) {
+  regs &= u16(~(1u << idx));
+}
 
 void reg_copy_known(u16& regs, u8 dst_idx, u8 src_idx) {
   regs = u16(regs & ~(1u << dst_idx)) | u16(((regs >> src_idx) & 1u) << dst_idx);
 }
 
 bool reg_intersect_known(u16& regs, u8 dst_idx, u8 src1_idx, u8 src2_idx) {
-  u16 const u{u16(u16(regs >> src1_idx) & u16(regs >> src2_idx) & 1u)};
+  u16 const u{ u16(u16(regs >> src1_idx) & u16(regs >> src2_idx) & 1u) };
   regs = u16(regs & ~(1u << dst_idx)) | u16(u << dst_idx);
   return bool(u);
 }
@@ -97,27 +93,36 @@ void cmp_imm_lit_set(reg_state& rs, u8 index, u32 lit) {
 }
 
 bool branch(u32 addr, func_state& s) {
-  auto const idx{unsigned((addr - s.func_start) / 2)};
+  auto const idx{ unsigned((addr - s.func_start) / 2) };
   if (idx > s.taken_branches.size()) {
     s.taken_branches.resize((idx + 1) * 2);
   }
 
-  if (s.taken_branches[idx]) { return false; }
+  if (s.taken_branches[idx]) {
+    return false;
+  }
   s.taken_branches[idx] = true;
   return true;
 }
 
 int inst_is_log_call(inst const& i,
                      std::vector<elf_symbol32 const*> const& log_funcs,
-                     char const *strtab) {
+                     char const* strtab) {
   u32 label;
-  if (!inst_is_unconditional_branch(i, label)) { return -1; }
+  if (!inst_is_unconditional_branch(i, label)) {
+    return -1;
+  }
 
-  auto const found{std::find_if(std::begin(log_funcs), std::end(log_funcs),
-    [=](elf_symbol32 const *cand) { return (cand->st_value & ~1u) == label; })};
-  if (found == std::end(log_funcs)) { return -1; }
+  auto const found{ std::find_if(
+      std::begin(log_funcs),
+      std::end(log_funcs),
+      [=](elf_symbol32 const* cand) { return (cand->st_value & ~1u) == label; }) };
+  if (found == std::end(log_funcs)) {
+    return -1;
+  }
 
-  char const *name{&strtab[(*found)->st_name]};
+  // clang-format off
+  char const* name{ &strtab[(*found)->st_name] };
   if (strstr(name, "_debug")) { return NL_SEV_DEBUG; }
   if (strstr(name, "_info")) { return NL_SEV_INFO; }
   if (strstr(name, "_warning")) { return NL_SEV_WARNING; }
@@ -126,25 +131,35 @@ int inst_is_log_call(inst const& i,
   if (strstr(name, "_assert")) { return NL_SEV_ASSERT; }
   if (strstr(name, "_sev")) { return UNCLOG_SEV_DYNAMIC; }
   if (strstr(name, "_buf")) { return UNCLOG_SEV_DYNAMIC; }
+  // clang-format on
+
   return -1;
 }
 
 bool table_branch(u32 addr, u32 sz, u32 base, u32 ofs, path_state& path, func_state& fs) {
-  if (base != reg::PC) { return false; }
+  if (base != reg::PC) {
+    return false;
+  }
 
   u32 cmp_imm_lit;
-  if (!cmp_imm_lit_get(path.rs, u8(ofs), cmp_imm_lit)) { return false; }
+  if (!cmp_imm_lit_get(path.rs, u8(ofs), cmp_imm_lit)) {
+    return false;
+  }
   ++cmp_imm_lit;
 
-  if (!branch(addr, fs)) { return true; }
+  if (!branch(addr, fs)) {
+    return true;
+  }
 
-  unsigned const src_off{fs.func_ofs + (addr - fs.func_start) + 4};
-  auto const *src{reinterpret_cast<unsigned char const *>(&fs.e.bytes[src_off])};
+  unsigned const src_off{ fs.func_ofs + (addr - fs.func_start) + 4 };
+  auto const* src{ reinterpret_cast<unsigned char const*>(&fs.e.bytes[src_off]) };
 
-  for (auto i{0u}; i < cmp_imm_lit; ++i) {
-    u32 val{*src++};
-    if (sz == 2) { val = u32(val | u32(*src++ << 8u)); }
-    u32 const label{path.rs.regs[reg::PC] + 4 + (val << 1u)};
+  for (auto i{ 0u }; i < cmp_imm_lit; ++i) {
+    u32 val{ *src++ };
+    if (sz == 2) {
+      val = u32(val | u32(*src++ << 8u));
+    }
+    u32 const label{ path.rs.regs[reg::PC] + 4 + (val << 1u) };
     fs.paths.push(path_state_branch(path, label));
   }
 
@@ -153,7 +168,7 @@ bool table_branch(u32 addr, u32 sz, u32 base, u32 ofs, path_state& path, func_st
 
 void process_it(inst_if_then const& it, path_state& path) {
   // Reorder "Table 4.1, pg 4-93" from 1230 to 3210, shifted to LSB.
-  u32 ord{u32(it.mask >> u8((4 - it.cnt) + 1))};
+  u32 ord{ u32(it.mask >> u8((4 - it.cnt) + 1)) };
   ord = (ord & 0b11110000) >> 4 | (ord & 0b00001111) << 4;
   ord = (ord & 0b11001100) >> 2 | (ord & 0b00110011) << 2;
   ord = (ord & 0b10101010) >> 1 | (ord & 0b01010101) << 1;
@@ -168,9 +183,11 @@ enum class simulate_results {
 };
 
 simulate_results process_ldr_pc_jump_table(inst const& i, path_state& p, func_state& fs) {
-  if (!branch(i.addr, fs)) { return simulate_results::TERMINATE_PATH; }
+  if (!branch(i.addr, fs)) {
+    return simulate_results::TERMINATE_PATH;
+  }
 
-  auto const& ldr{i.i.load_reg};
+  auto const& ldr{ i.i.load_reg };
 
   if (!reg_test_known(p.rs.known, ldr.n)) {
     NL_LOG_ERR("  Unknown PC-rel load, stopping\n");
@@ -184,15 +201,20 @@ simulate_results process_ldr_pc_jump_table(inst const& i, path_state& p, func_st
   }
 
   if (ldr.shift.n != 2) {
-    NL_LOG_ERR("  PC-rel load, %s shift is %d (expected 2)\n", reg_name(ldr.m),
-      int(ldr.shift.n));
+    NL_LOG_ERR("  PC-rel load, %s shift is %d (expected 2)\n",
+               reg_name(ldr.m),
+               int(ldr.shift.n));
     return simulate_results::FAILURE;
   }
-  NL_LOG_DBG("  Known PC-rel load: %s: %x, %d entries\n", reg_name(ldr.n),
-    unsigned(p.rs.regs[ldr.n]), cmp_lit);
+  NL_LOG_DBG("  Known PC-rel load: %s: %x, %d entries\n",
+             reg_name(ldr.n),
+             unsigned(p.rs.regs[ldr.n]),
+             cmp_lit);
 
-  unsigned char const *src{&fs.e.bytes[fs.func_ofs + (p.rs.regs[ldr.n] - fs.func_start)]};
-  for (u32 idx{0u}; idx <= cmp_lit; ++idx) {
+  unsigned char const* src{
+    &fs.e.bytes[fs.func_ofs + (p.rs.regs[ldr.n] - fs.func_start)]
+  };
+  for (u32 idx{ 0u }; idx <= cmp_lit; ++idx) {
     u32 jump_label;
     memcpy(&jump_label, src, 4);
     src += 4;
@@ -206,22 +228,22 @@ simulate_results simulate(inst const& i,
                           u32_set const& noreturn_func_addrs,
                           func_state& fs,
                           path_state& path) {
-  bool const it_skip{path.it_rem && !(path.it_flags & 1)};
+  bool const it_skip{ path.it_rem && !(path.it_flags & 1) };
   if (NL_UNLIKELY(path.it_rem)) {
     --path.it_rem;
     path.it_flags >>= 1u;
   }
-  if (NL_UNLIKELY(it_skip)) { // If inside an if-then and skip bit, don't sim.
+  if (NL_UNLIKELY(it_skip)) {  // If inside an if-then and skip bit, don't sim.
     path.rs.regs[reg::PC] += i.len;
     return simulate_results::SUCCESS;
   }
 
-  std::vector<reg_mut_node>& reg_muts{fs.lca.reg_muts};
+  std::vector<reg_mut_node>& reg_muts{ fs.lca.reg_muts };
 
   switch (i.type) {
     case inst_type::ADD_IMM: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& add{i.i.add_imm};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& add{ i.i.add_imm };
       path.rs.regs[dst_reg] = path.rs.regs[add.n] + add.imm;
       reg_copy_known(path.rs.known, u8(dst_reg), add.n);
       reg_muts.emplace_back(i, path.rs.mut_node_idxs[add.n]);
@@ -229,19 +251,18 @@ simulate_results simulate(inst const& i,
     } break;
 
     case inst_type::ADD_REG: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& add{i.i.add_reg};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& add{ i.i.add_reg };
       path.rs.regs[dst_reg] = path.rs.regs[add.n] + path.rs.regs[add.m];
       reg_intersect_known(path.rs.known, u8(dst_reg), add.m, add.n);
-      reg_muts.emplace_back(i, path.rs.mut_node_idxs[add.n],
-        path.rs.mut_node_idxs[add.m]);
+      reg_muts.emplace_back(i, path.rs.mut_node_idxs[add.n], path.rs.mut_node_idxs[add.m]);
       path.rs.mut_node_idxs[dst_reg] = u32(reg_muts.size() - 1u);
     } break;
 
     case inst_type::ADR: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& adr{i.i.adr};
-      u32 const base{inst_align(path.rs.regs[reg::PC], 4) + 4};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& adr{ i.i.adr };
+      u32 const base{ inst_align(path.rs.regs[reg::PC], 4) + 4 };
       path.rs.regs[dst_reg] = adr.add ? (base + adr.imm) : (base - adr.imm);
       reg_mark_known(path.rs.known, dst_reg);
       reg_muts.emplace_back(i);
@@ -249,15 +270,18 @@ simulate_results simulate(inst const& i,
     } break;
 
     case inst_type::BRANCH: {
-      auto const& b{i.i.branch};
-      bool const addr_in_func{address_in_func(b.addr, fs)}, cond{!cond_code_is_always(b.cc)};
+      auto const& b{ i.i.branch };
+      bool const addr_in_func{ address_in_func(b.addr, fs) },
+          cond{ !cond_code_is_always(b.cc) };
       if (!cond) {
         if (!addr_in_func) {
           NL_LOG_DBG("  Stopping Path: Unconditional branch out of function\n");
           return simulate_results::TERMINATE_PATH;
         }
 
-        if (!branch(i.addr, fs)) { return simulate_results::TERMINATE_PATH; }
+        if (!branch(i.addr, fs)) {
+          return simulate_results::TERMINATE_PATH;
+        }
         path.rs.regs[reg::PC] = b.addr;
         return simulate_results::SUCCESS;
       } else {
@@ -269,16 +293,17 @@ simulate_results simulate(inst const& i,
     } break;
 
     case inst_type::BRANCH_LINK: {
-      auto const& bl{i.i.branch_link};
+      auto const& bl{ i.i.branch_link };
       fs.lca.subs.push_back(bl.addr);
       if (noreturn_func_addrs.contains(bl.addr)) {
         NL_LOG_DBG("  Stopping path: noreturn call\n");
         return simulate_results::TERMINATE_PATH;
       }
-      path.rs.known &= 0xFFF0u; // r0-r3 are scratch
+      path.rs.known &= 0xFFF0u;  // r0-r3 are scratch
     } break;
 
-    case inst_type::BRANCH_XCHG: return simulate_results::TERMINATE_PATH; // tail call
+    case inst_type::BRANCH_XCHG:
+      return simulate_results::TERMINATE_PATH;  // tail call
 
     case inst_type::CBNZ:
       if (branch(i.addr, fs)) {
@@ -308,37 +333,40 @@ simulate_results simulate(inst const& i,
       break;
 
     case inst_type::LOAD_IMM: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      if (dst_reg == reg::PC) { return simulate_results::TERMINATE_PATH; }
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      if (dst_reg == reg::PC) {
+        return simulate_results::TERMINATE_PATH;
+      }
       reg_clear_known(path.rs.known, dst_reg);
     } break;
 
     case inst_type::LOAD_LIT: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& ldr{i.i.load_lit};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& ldr{ i.i.load_lit };
       memcpy(&path.rs.regs[dst_reg],
-        &fs.e.bytes[fs.func_ofs + (ldr.addr - fs.func_start)], 4);
+             &fs.e.bytes[fs.func_ofs + (ldr.addr - fs.func_start)],
+             4);
       reg_mark_known(path.rs.known, dst_reg);
       reg_muts.push_back(reg_mut_node(i));
       path.rs.mut_node_idxs[dst_reg] = u32(reg_muts.size() - 1u);
     } break;
 
     case inst_type::LOAD_REG: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& ldr{i.i.load_reg};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& ldr{ i.i.load_reg };
       if (dst_reg == reg::PC) {
         return process_ldr_pc_jump_table(i, path, fs);
       } else {
-        bool const known{reg_intersect_known(path.rs.known, u8(dst_reg), ldr.n, ldr.m)};
-        u32 const addr{u32(path.rs.regs[ldr.n] + (path.rs.regs[ldr.m] << ldr.shift.n))};
+        bool const known{ reg_intersect_known(path.rs.known, u8(dst_reg), ldr.n, ldr.m) };
+        u32 const addr{ u32(path.rs.regs[ldr.n] + (path.rs.regs[ldr.m] << ldr.shift.n)) };
         if (known && address_in_func(addr, fs)) {
-          unsigned const ofs{fs.func_ofs + (addr - fs.func_start)};
+          unsigned const ofs{ fs.func_ofs + (addr - fs.func_start) };
           memcpy(&path.rs.regs[dst_reg], &fs.e.bytes[ofs], 4);
         }
       }
     } break;
 
-    case inst_type::LOAD_MULT_INC_AFTER: // LDMIA SP!, { ... PC }
+    case inst_type::LOAD_MULT_INC_AFTER:  // LDMIA SP!, { ... PC }
       if (i.dr & (1u << reg::PC)) {
         return simulate_results::TERMINATE_PATH;
       }
@@ -346,8 +374,8 @@ simulate_results simulate(inst const& i,
       break;
 
     case inst_type::MOV_IMM: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& mov{i.i.mov_imm};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& mov{ i.i.mov_imm };
       path.rs.regs[dst_reg] = mov.imm;
       reg_mark_known(path.rs.known, dst_reg);
       reg_muts.emplace_back(i);
@@ -355,8 +383,8 @@ simulate_results simulate(inst const& i,
     } break;
 
     case inst_type::MOV_NEG_IMM: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& mvn{i.i.mov_neg_imm};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& mvn{ i.i.mov_neg_imm };
       path.rs.regs[dst_reg] = ~u32(mvn.imm);
       reg_mark_known(path.rs.known, dst_reg);
       reg_muts.emplace_back(i);
@@ -364,8 +392,8 @@ simulate_results simulate(inst const& i,
     } break;
 
     case inst_type::MOV_REG: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& mov{i.i.mov_reg};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& mov{ i.i.mov_reg };
       path.rs.regs[dst_reg] = path.rs.regs[mov.m];
       reg_copy_known(path.rs.known, u8(dst_reg), mov.m);
       reg_muts.emplace_back(i, path.rs.mut_node_idxs[mov.m]);
@@ -373,13 +401,15 @@ simulate_results simulate(inst const& i,
     } break;
 
     case inst_type::POP:
-      if (i.dr & (1u << reg::PC)) { return simulate_results::TERMINATE_PATH; }
+      if (i.dr & (1u << reg::PC)) {
+        return simulate_results::TERMINATE_PATH;
+      }
       path.rs.known &= ~i.dr;
       break;
 
     case inst_type::SUB_REV_IMM: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& sub{i.i.sub_rev_imm};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& sub{ i.i.sub_rev_imm };
       path.rs.regs[dst_reg] = sub.imm - path.rs.regs[sub.n];
       reg_copy_known(path.rs.known, u8(dst_reg), sub.n);
       reg_muts.emplace_back(i, path.rs.mut_node_idxs[sub.n]);
@@ -387,8 +417,8 @@ simulate_results simulate(inst const& i,
     } break;
 
     case inst_type::SUB_IMM: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& sub{i.i.sub_imm};
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& sub{ i.i.sub_imm };
       path.rs.regs[dst_reg] = path.rs.regs[sub.n] - sub.imm;
       reg_copy_known(path.rs.known, u8(dst_reg), sub.n);
       reg_muts.push_back(reg_mut_node(i, path.rs.mut_node_idxs[sub.n]));
@@ -396,16 +426,16 @@ simulate_results simulate(inst const& i,
     } break;
 
     case inst_type::SUB_REG: {
-      int const dst_reg{inst_reg_from_bitmask(i.dr)};
-      auto const& sub{i.i.sub_reg};
-      path.rs.regs[dst_reg] = path.rs.regs[sub.n] - path.rs.regs[sub.m]; // shift
+      int const dst_reg{ inst_reg_from_bitmask(i.dr) };
+      auto const& sub{ i.i.sub_reg };
+      path.rs.regs[dst_reg] = path.rs.regs[sub.n] - path.rs.regs[sub.m];  // shift
       reg_intersect_known(path.rs.known, u8(dst_reg), sub.n, sub.m);
       reg_muts.emplace_back(i, path.rs.mut_node_idxs[sub.n], path.rs.mut_node_idxs[sub.m]);
       path.rs.mut_node_idxs[dst_reg] = u32(reg_muts.size() - 1u);
     } break;
 
     case inst_type::TABLE_BRANCH_HALF: {
-      auto const& tbh{i.i.table_branch_half};
+      auto const& tbh{ i.i.table_branch_half };
       if (NL_UNLIKELY(!table_branch(i.addr, 2, tbh.n, tbh.m, path, fs))) {
         NL_LOG_ERR("  TBH failure\n");
         return simulate_results::FAILURE;
@@ -414,7 +444,7 @@ simulate_results simulate(inst const& i,
     }
 
     case inst_type::TABLE_BRANCH_BYTE: {
-      auto const& tbb{i.i.table_branch_byte};
+      auto const& tbb{ i.i.table_branch_byte };
       if (NL_UNLIKELY(!table_branch(i.addr, 1, tbb.n, tbb.m, path, fs))) {
         NL_LOG_ERR("  TBB failure\n");
         return simulate_results::FAILURE;
@@ -422,7 +452,8 @@ simulate_results simulate(inst const& i,
       return simulate_results::TERMINATE_PATH;
     }
 
-    case inst_type::UNDEFINED: return simulate_results::TERMINATE_PATH;
+    case inst_type::UNDEFINED:
+      return simulate_results::TERMINATE_PATH;
 
     default:
       path.rs.known &= ~i.dr;
@@ -452,31 +483,38 @@ process_log_call_ret process_log_call(inst const& pc_i,
     return PROCESS_LOG_CALL_RET_ERR_R0_UNKNOWN;
   }
 
-  u32 const fmt_str_addr{path.rs.regs[reg::R0]};
-  if (nl_sec_hdr.sh_size &&
-      ((fmt_str_addr < nl_sec_hdr.sh_addr) ||
-       (fmt_str_addr > (nl_sec_hdr.sh_addr + nl_sec_hdr.sh_size)))) {
+  u32 const fmt_str_addr{ path.rs.regs[reg::R0] };
+  if (nl_sec_hdr.sh_size && ((fmt_str_addr < nl_sec_hdr.sh_addr) ||
+                             (fmt_str_addr > (nl_sec_hdr.sh_addr + nl_sec_hdr.sh_size)))) {
     NL_LOG_ERR("  Found log function, R0 is invalid: 0x%08x\n", fmt_str_addr);
     return PROCESS_LOG_CALL_RET_ERR_R0_INVALID;
   }
 
-  auto [_, inserted]{fs.discovered_log_strs.insert(fmt_str_addr)};
+  auto [_, inserted]{ fs.discovered_log_strs.insert(fmt_str_addr) };
   if (!inserted) {
     NL_LOG_DBG("  Found log function, already discovered\n");
     return PROCESS_LOG_CALL_RET_ERR_ALREADY_DISCOVERED;
   }
 
   lca.log_calls.push_back(log_call{ .fmt_str_addr = path.rs.regs[reg::R0],
-    .log_func_call_addr = pc_i.addr, .node_idx = path.rs.mut_node_idxs[reg::R0],
-    .s = fmt_str_strat::UNKNOWN, .severity = u8(sev)});
-  auto& log_call{lca.log_calls[lca.log_calls.size() - 1]};
+                                    .log_func_call_addr = pc_i.addr,
+                                    .node_idx = path.rs.mut_node_idxs[reg::R0],
+                                    .s = fmt_str_strat::UNKNOWN,
+                                    .severity = u8(sev) });
+  auto& log_call{ lca.log_calls[lca.log_calls.size() - 1] };
 
   NL_LOG_DBG("  Found log function, format string 0x%08x\n", path.rs.regs[reg::R0]);
-  inst const& r0_i{lca.reg_muts[path.rs.mut_node_idxs[reg::R0]].i};
+  inst const& r0_i{ lca.reg_muts[path.rs.mut_node_idxs[reg::R0]].i };
   switch (r0_i.type) {
-    case inst_type::LOAD_LIT: log_call.s = fmt_str_strat::DIRECT_LOAD; break;
-    case inst_type::MOV_REG:  log_call.s = fmt_str_strat::MOV_FROM_DIRECT_LOAD; break;
-    case inst_type::ADD_IMM:  log_call.s = fmt_str_strat::ADD_IMM_FROM_BASE_REG; break;
+    case inst_type::LOAD_LIT:
+      log_call.s = fmt_str_strat::DIRECT_LOAD;
+      break;
+    case inst_type::MOV_REG:
+      log_call.s = fmt_str_strat::MOV_FROM_DIRECT_LOAD;
+      break;
+    case inst_type::ADD_IMM:
+      log_call.s = fmt_str_strat::ADD_IMM_FROM_BASE_REG;
+      break;
     default:
       NL_LOG_DBG("Unrecognized pattern!\n***\n");
       NL_LOG_DBG("0x%x\n", r0_i.addr);
@@ -486,11 +524,13 @@ process_log_call_ret process_log_call(inst const& pc_i,
   }
   return PROCESS_LOG_CALL_RET_SUCCESS;
 }
-}
+}  // namespace
 
-char const *fmt_str_strat_name(fmt_str_strat s) {
-#define X(NAME) case fmt_str_strat::NAME: return #NAME;
-  switch (s) { FMT_STR_STRAT_LIST() default: return "unknown"; }
+char const* fmt_str_strat_name(fmt_str_strat s) {
+#define X(NAME) \
+  case fmt_str_strat::NAME: \
+    return #NAME;
+  switch (s) { FMT_STR_STRAT_LIST() default : return "unknown"; }
 #undef X
 }
 
@@ -502,32 +542,36 @@ thumb2_analyze_func_ret thumb2_analyze_func(
     u32_set const& noreturn_func_addrs,
     func_log_call_analysis& out_lca,
     analysis_stats& out_stats) {
-  func_state s{func, e, e.sec_hdrs[func.st_shndx], out_lca};
-  s.taken_branches.resize(1024 * 1024); //(s.func_end - s.func_start) / 2);
+  func_state s{ func, e, e.sec_hdrs[func.st_shndx], out_lca };
+  s.taken_branches.resize(1024 * 1024);  //(s.func_end - s.func_start) / 2);
 
   out_lca.reg_muts.reserve(1024);
 
   NL_LOG_DBG("\nScanning %s: addr %x, len %x, range %x-%x, offset %x:\n",
-    &e.strtab[func.st_name], func.st_value, func.st_size, s.func_start, s.func_end,
-    s.func_ofs);
+             &e.strtab[func.st_name],
+             func.st_value,
+             func.st_size,
+             s.func_start,
+             s.func_end,
+             s.func_ofs);
 
-  s.paths.push([&]() { // set up the function entry point on the path stack
+  s.paths.push([&]() {  // set up the function entry point on the path stack
     path_state ps;
     ps.it_rem = 0;
     ps.rs.regs[reg::PC] = s.func_start;
     return ps;
   }());
 
-  bool const debug{nanolog_get_threshold() == NL_SEV_DEBUG};
+  bool const debug{ nanolog_get_threshold() == NL_SEV_DEBUG };
 
-  auto path_count{0};
-  while (!s.paths.empty()) { // recurse through the function
+  auto path_count{ 0 };
+  while (!s.paths.empty()) {  // recurse through the function
     if (++path_count > 1024) {
       NL_LOG_ERR("  Stopping analysis, infinite loop.");
       return thumb2_analyze_func_ret::ERR_INFINITE_LOOP;
     }
 
-    path_state path{s.paths.top()};
+    path_state path{ s.paths.top() };
     s.paths.pop();
 
     NL_LOG_DBG("  Starting path (%d in stack)\n", int(s.paths.size()));
@@ -540,8 +584,10 @@ thumb2_analyze_func_ret thumb2_analyze_func(
       }
 
       inst pc_i;
-      bool const decode_ok{inst_decode(&e.bytes[s.func_ofs], s.func_start,
-        path.rs.regs[reg::PC] - s.func_start, pc_i)};
+      bool const decode_ok{ inst_decode(&e.bytes[s.func_ofs],
+                                        s.func_start,
+                                        path.rs.regs[reg::PC] - s.func_start,
+                                        pc_i) };
 
       ++out_stats.decoded_insts;
 
@@ -561,7 +607,7 @@ thumb2_analyze_func_ret thumb2_analyze_func(
         return thumb2_analyze_func_ret::ERR_INSTRUCTION_DECODE;
       }
 
-      if (int const sev{inst_is_log_call(pc_i, log_funcs, e.strtab)};
+      if (int const sev{ inst_is_log_call(pc_i, log_funcs, e.strtab) };
           NL_UNLIKELY(sev != -1)) {
         bool already_discovered = false;
         switch (process_log_call(pc_i, path, nl_sec_hdr, sev, s, out_lca)) {
@@ -584,7 +630,7 @@ thumb2_analyze_func_ret thumb2_analyze_func(
         }
       }
 
-      simulate_results const sr{simulate(pc_i, noreturn_func_addrs, s, path)};
+      simulate_results const sr{ simulate(pc_i, noreturn_func_addrs, s, path) };
       if (NL_UNLIKELY(sr == simulate_results::FAILURE)) {
         return thumb2_analyze_func_ret::ERR_SIMULATE_LOGIC_INCOMPLETE;
       }
@@ -604,23 +650,23 @@ bool thumb2_patch_fmt_strs(elf const& e,
                            byte* patched_elf,
                            std::vector<func_log_call_analysis> const& log_call_funcs,
                            u32_vec const& fmt_bin_addrs) {
-  for (u32 i{0}; auto const &func : log_call_funcs) {
-    u32 const func_ofs{e.sec_hdrs[func.func.st_shndx].sh_offset},
-      func_addr{e.sec_hdrs[func.func.st_shndx].sh_addr};
+  for (u32 i{ 0 }; auto const& func : log_call_funcs) {
+    u32 const func_ofs{ e.sec_hdrs[func.func.st_shndx].sh_offset },
+        func_addr{ e.sec_hdrs[func.func.st_shndx].sh_addr };
 
-    for (auto const &log_call : func.log_calls) {
-      auto const& r0_mut{func.reg_muts[log_call.node_idx]};
-      u32 const bin_addr{fmt_bin_addrs[i] + nl_sec_hdr.sh_addr};
+    for (auto const& log_call : func.log_calls) {
+      auto const& r0_mut{ func.reg_muts[log_call.node_idx] };
+      u32 const bin_addr{ fmt_bin_addrs[i] + nl_sec_hdr.sh_addr };
 
       switch (log_call.s) {
         case fmt_str_strat::DIRECT_LOAD: {
-          unsigned const dst_ofs{func_ofs + (r0_mut.i.i.load_lit.addr - func_addr)};
+          unsigned const dst_ofs{ func_ofs + (r0_mut.i.i.load_lit.addr - func_addr) };
           memcpy(&patched_elf[dst_ofs], &bin_addr, sizeof(u32));
         } break;
 
         case fmt_str_strat::MOV_FROM_DIRECT_LOAD: {
-          reg_mut_node const& rn_mut{func.reg_muts[r0_mut.par_idxs[0]]};
-          unsigned const dst_ofs{func_ofs + (rn_mut.i.i.load_lit.addr - func_addr)};
+          reg_mut_node const& rn_mut{ func.reg_muts[r0_mut.par_idxs[0]] };
+          unsigned const dst_ofs{ func_ofs + (rn_mut.i.i.load_lit.addr - func_addr) };
           memcpy(&patched_elf[dst_ofs], &bin_addr, sizeof(u32));
         } break;
 
@@ -639,4 +685,3 @@ bool thumb2_patch_fmt_strs(elf const& e,
 
   return true;
 }
-

--- a/unclog/thumb2.h
+++ b/unclog/thumb2.h
@@ -14,10 +14,10 @@ struct elf_symbol32;
   X(ADD_IMM_FROM_BASE_REG)
 
 #define X(NAME) NAME,
-enum class fmt_str_strat: u8 { FMT_STR_STRAT_LIST() };
+enum class fmt_str_strat : u8 { FMT_STR_STRAT_LIST() };
 #undef X
 
-char const *fmt_str_strat_name(fmt_str_strat s);
+char const* fmt_str_strat_name(fmt_str_strat s);
 
 struct log_call {
   u32 fmt_str_addr;
@@ -29,10 +29,13 @@ struct log_call {
 
 struct reg_mut_node {
   explicit reg_mut_node(inst const& i_,
-                        u32 par_idx0=0xFFFFFFFFu,
-                        u32 par_idx1=0xFFFFFFFFu,
-                        u32 par_idx2=0xFFFFFFFFu) : i(i_) {
-    par_idxs[0] = par_idx0; par_idxs[1] = par_idx1; par_idxs[2] = par_idx2;
+                        u32 par_idx0 = 0xFFFFFFFFu,
+                        u32 par_idx1 = 0xFFFFFFFFu,
+                        u32 par_idx2 = 0xFFFFFFFFu)
+      : i(i_) {
+    par_idxs[0] = par_idx0;
+    par_idxs[1] = par_idx1;
+    par_idxs[2] = par_idx2;
   }
   inst i;
   u32 par_idxs[3];
@@ -61,13 +64,13 @@ enum thumb2_analyze_func_ret {
 };
 
 thumb2_analyze_func_ret thumb2_analyze_func(
-  elf const& e,
-  elf_symbol32 const& func,
-  elf_section_hdr32 const& nl_sec_hdr,
-  std::vector<elf_symbol32 const*> const& log_funcs,
-  u32_set const& noreturn_func_addrs,
-  func_log_call_analysis& out_lca,
-  analysis_stats& out_stats);
+    elf const& e,
+    elf_symbol32 const& func,
+    elf_section_hdr32 const& nl_sec_hdr,
+    std::vector<elf_symbol32 const*> const& log_funcs,
+    u32_set const& noreturn_func_addrs,
+    func_log_call_analysis& out_lca,
+    analysis_stats& out_stats);
 
 bool thumb2_patch_fmt_strs(elf const& e,
                            elf_section_hdr32 const& nl_sec_hdr,

--- a/unclog/thumb2_inst.cc
+++ b/unclog/thumb2_inst.cc
@@ -7,42 +7,53 @@
 
 namespace {
 
-char const *cond_code_name(cond_code cc) {
-#define X(NAME, VAL) case cond_code::NAME: return #NAME;
+char const* cond_code_name(cond_code cc) {
+#define X(NAME, VAL) \
+  case cond_code::NAME: \
+    return #NAME;
   switch (cc) { CONDITION_CODE_X_LIST() }
 #undef X
   return "unknown";
 }
 
 #define X(NAME) #NAME,
-char const *s_rn[] = { REGISTER_X_LIST() };
+char const* s_rn[] = { REGISTER_X_LIST() };
 #undef X
 
 #define X(NAME) #NAME,
-char const *s_sn[] = { SHIFT_X_LIST() };
+char const* s_sn[] = { SHIFT_X_LIST() };
 #undef X
 
-u32 decode_imm12(u32 imm12) { // 4.2.2 Operation (pg 4-9)
+u32 decode_imm12(u32 imm12) {  // 4.2.2 Operation (pg 4-9)
   if ((imm12 & 0xC00u) == 0) {
-    u32 const imm8{imm12 & 0xFFu};
+    u32 const imm8{ imm12 & 0xFFu };
     switch ((imm12 >> 8u) & 3u) {
-      case 0: return imm12;
-      case 1: return (imm8 << 16) | imm8;
-      case 2: return (imm8 << 24) | (imm8 << 8);
-      case 3: return (imm8 << 24) | (imm8 << 16) | (imm8 << 8) | imm8;
+      case 0:
+        return imm12;
+      case 1:
+        return (imm8 << 16) | imm8;
+      case 2:
+        return (imm8 << 24) | (imm8 << 8);
+      case 3:
+        return (imm8 << 24) | (imm8 << 16) | (imm8 << 8) | imm8;
     }
   }
-  u32 const x{0x80u | (imm12 & 0x7Fu)}, n{(imm12 >> 7u) & 0x1Fu};
+  u32 const x{ 0x80u | (imm12 & 0x7Fu) }, n{ (imm12 >> 7u) & 0x1Fu };
   return (x >> n) | (x << (32 - n));
 }
 
 imm_shift decode_imm_shift(u8 const type, u8 const imm5) {
   switch (type & 3u) {  // 4.3.2 Shift Operations (pg 4-11)
-    case 0b00: return imm_shift{ .t = imm_shift_type::LSL, .n = imm5 };
-    case 0b01: return imm_shift{ .t = imm_shift_type::LSR, .n = imm5 ? imm5 : u8(32) };
-    case 0b10: return imm_shift{ .t = imm_shift_type::ASR, .n = imm5 ? imm5 : u8(32) };
+    case 0b00:
+      return imm_shift{ .t = imm_shift_type::LSL, .n = imm5 };
+    case 0b01:
+      return imm_shift{ .t = imm_shift_type::LSR, .n = imm5 ? imm5 : u8(32) };
+    case 0b10:
+      return imm_shift{ .t = imm_shift_type::ASR, .n = imm5 ? imm5 : u8(32) };
     case 0b11:
-      if (imm5 == 0u) { return imm_shift{ .t = imm_shift_type::RRX, .n = 1 }; }
+      if (imm5 == 0u) {
+        return imm_shift{ .t = imm_shift_type::RRX, .n = 1 };
+      }
       return imm_shift{ .t = imm_shift_type::ROR, .n = imm5 };
   }
 #ifdef _MSC_VER
@@ -59,11 +70,12 @@ float decode_vfp_imm8(u8 imm8, unsigned n) {
   (void)n;
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4146)
+#pragma warning(disable : 4146)
 #endif
-  u32 const replicate{(-((imm8 >> 6u) & 1u)) & 0x1Fu}, imm8_5_0{imm8 & 0x3Fu},
-    not_imm8_6{!((imm8 >> 6u) & 1u)}, imm8_7{(imm8 >> 7u) & 1u},
-    imm{(imm8_7 << 31u) | (not_imm8_6 << 30u) | (replicate << 24u) | (imm8_5_0 << 19u)};
+  u32 const replicate{ (-((imm8 >> 6u) & 1u)) & 0x1Fu }, imm8_5_0{ imm8 & 0x3Fu },
+      not_imm8_6{ !((imm8 >> 6u) & 1u) }, imm8_7{ (imm8 >> 7u) & 1u },
+      imm{ (imm8_7 << 31u) | (not_imm8_6 << 30u) | (replicate << 24u) |
+           (imm8_5_0 << 19u) };
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -84,33 +96,36 @@ bool is_16bit_inst(u16 w0) {
 bool decode_16bit_inst(u16 const w0, inst& out_inst) {
   out_inst.len = 2;
 
-  if ((w0 & 0xFFC0u) == 0x4140u) { // 4.6.2 ADC (reg), T1 encoding (pg 4-18)
+  if ((w0 & 0xFFC0u) == 0x4140u) {  // 4.6.2 ADC (reg), T1 encoding (pg 4-18)
     out_inst.type = inst_type::ADD_CARRY_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
-    out_inst.i.add_carry_reg = { .shift = decode_imm_shift(0b00, 0),
-      .n = u8(w0 & 7u), .m = u8((w0 >> 3u) & 7u),  };
+    out_inst.i.add_carry_reg = {
+      .shift = decode_imm_shift(0b00, 0),
+      .n = u8(w0 & 7u),
+      .m = u8((w0 >> 3u) & 7u),
+    };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x1C00u) { // 4.6.3 ADD (imm), T1 encoding (pg 4-20)
+  if ((w0 & 0xFE00u) == 0x1C00u) {  // 4.6.3 ADD (imm), T1 encoding (pg 4-20)
     out_inst.type = inst_type::ADD_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.add_imm = { .imm = u16((w0 >> 6u) & 7u), .n = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x3000u) { // 4.6.3 ADD (imm), T2 encoding (pg 4-20)
-    u8 const dn{u8((w0 >> 8u) & 7u)};
+  if ((w0 & 0xF800u) == 0x3000u) {  // 4.6.3 ADD (imm), T2 encoding (pg 4-20)
+    u8 const dn{ u8((w0 >> 8u) & 7u) };
     out_inst.type = inst_type::ADD_IMM;
     out_inst.dr = u16(1u << dn);
     out_inst.i.add_imm = { .imm = u8(w0 & 0xFFu), .n = dn };
     return true;
   }
 
-  if ((w0 & 0xFF00u) == 0x4400u) { // 4.6.4 ADD (reg), T2 encoding (pg 4-22)
-    u8 const dn{u8((w0 >> 7u) & 1u)}, rdn{u8(w0 & 7u)}, d{u8((dn << 3) | rdn)},
-      m{u8((w0 >> 3u) & 7u)};
-    if ((d == 13) || (m == 13)) { // 4.6.6 ADD (SP plus reg), T2 encoding (pg 4-26)
+  if ((w0 & 0xFF00u) == 0x4400u) {  // 4.6.4 ADD (reg), T2 encoding (pg 4-22)
+    u8 const dn{ u8((w0 >> 7u) & 1u) }, rdn{ u8(w0 & 7u) }, d{ u8((dn << 3) | rdn) },
+        m{ u8((w0 >> 3u) & 7u) };
+    if ((d == 13) || (m == 13)) {  // 4.6.6 ADD (SP plus reg), T2 encoding (pg 4-26)
       out_inst.type = inst_type::ADD_SP_IMM;
       out_inst.dr = u16(1u << d);
       out_inst.i.add_sp_imm = { .imm = d };
@@ -122,471 +137,527 @@ bool decode_16bit_inst(u16 const w0, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x1800u) { // 4.6.4 ADD (reg), T1 encoding (pg 4-22)
+  if ((w0 & 0xFE00u) == 0x1800u) {  // 4.6.4 ADD (reg), T1 encoding (pg 4-22)
     out_inst.type = inst_type::ADD_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
-    out_inst.i.add_reg = { .shift = decode_imm_shift(0b00, 0), .n = u8((w0 >> 3u) & 7u),
-      .m = u8((w0 >> 6u) & 7u) };
+    out_inst.i.add_reg = { .shift = decode_imm_shift(0b00, 0),
+                           .n = u8((w0 >> 3u) & 7u),
+                           .m = u8((w0 >> 6u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0xA800u) { // 4.5.5 ADD (SP + imm), T1 encoding (pg 4-24)
+  if ((w0 & 0xF800u) == 0xA800u) {  // 4.5.5 ADD (SP + imm), T1 encoding (pg 4-24)
     out_inst.type = inst_type::ADD_SP_IMM;
     out_inst.dr = u16(1u << ((w0 >> 8u) & 7u));
     out_inst.i.add_sp_imm = { .imm = u16((w0 & 0xFFu) << 2u) };
     return true;
   }
 
-  if ((w0 & 0xFF80u) == 0xB000u) { // 4.6.5 ADD (SP + imm), T1 encoding (pg 4-24)
+  if ((w0 & 0xFF80u) == 0xB000u) {  // 4.6.5 ADD (SP + imm), T1 encoding (pg 4-24)
     out_inst.type = inst_type::ADD_SP_IMM;
     out_inst.dr = u16(1u << reg::SP);
     out_inst.i.add_sp_imm = { .imm = u16((w0 & 0x7Fu) << 2u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0xA000u) { // 4.6.7 ADR, T1 encoding (pg 4-28)
+  if ((w0 & 0xF800u) == 0xA000u) {  // 4.6.7 ADR, T1 encoding (pg 4-28)
     out_inst.type = inst_type::ADR;
     out_inst.dr = u16(1u << ((w0 >> 8u) & 7u));
     out_inst.i.adr = { .imm = u8((w0 & 0xFFu) << 2u), .add = 1u };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4000u) { // 4.6.9 AND, T1 encoding (pg 4-32)
+  if ((w0 & 0xFFC0u) == 0x4000u) {  // 4.6.9 AND, T1 encoding (pg 4-32)
     out_inst.type = inst_type::AND_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
-    out_inst.i.and_reg = { .shift = decode_imm_shift(0b00, 0), .n = u8(w0 & 7u),
-      .m = u8((w0 >> 3u) & 7u) };
+    out_inst.i.and_reg = { .shift = decode_imm_shift(0b00, 0),
+                           .n = u8(w0 & 7u),
+                           .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800) == 0x1000u) { // 4.6.10 ASR (imm), T1 encoding (pg 4-34)
+  if ((w0 & 0xF800) == 0x1000u) {  // 4.6.10 ASR (imm), T1 encoding (pg 4-34)
     out_inst.type = inst_type::RSHIFT_ARITH_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.rshift_arith_imm = { .shift = decode_imm_shift(0b10, (w0 >> 6u) & 0x1Fu),
-      .m = u8((w0 >> 3u) & 7u) };
+                                    .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4100u) { // 4.6.11 ASR (reg), T1 encoding (pg 4-36)
-    u8 const dn{u8(w0 & 7u)};
+  if ((w0 & 0xFFC0u) == 0x4100u) {  // 4.6.11 ASR (reg), T1 encoding (pg 4-36)
+    u8 const dn{ u8(w0 & 7u) };
     out_inst.type = inst_type::RSHIFT_ARITH_REG;
     out_inst.dr = u16(1u << dn);
     out_inst.i.rshift_arith_reg = { .n = dn, .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF000u) == 0xD000u) { // 4.6.12 B, T1 encoding (pg 4-38)
-    cond_code const cc{cond_code(((w0 >> 8u) & 0xFu))};
-    u32 const imm32{u32(sext((w0 & 0xFFu) << 1u, 8u))};
-    if (u8(cc) == 0xFu) { // cc 0b1111 == SVC, 4.6.181 SVC (pg 4-375)
-      out_inst.type = inst_type::SVC; out_inst.i.svc = { .imm = imm32 };
-    } if (u8(cc) == 0xEu) { // cc 0b1110 == undefined
+  if ((w0 & 0xF000u) == 0xD000u) {  // 4.6.12 B, T1 encoding (pg 4-38)
+    cond_code const cc{ cond_code(((w0 >> 8u) & 0xFu)) };
+    u32 const imm32{ u32(sext((w0 & 0xFFu) << 1u, 8u)) };
+    if (u8(cc) == 0xFu) {  // cc 0b1111 == SVC, 4.6.181 SVC (pg 4-375)
+      out_inst.type = inst_type::SVC;
+      out_inst.i.svc = { .imm = imm32 };
+    }
+    if (u8(cc) == 0xEu) {  // cc 0b1110 == undefined
       out_inst.type = inst_type::UNDEFINED;
     } else {
-      out_inst.type = inst_type::BRANCH; out_inst.i.branch = { .imm = imm32,
-        .addr = u32(out_inst.addr + 4u + imm32), .cc = cc };
+      out_inst.type = inst_type::BRANCH;
+      out_inst.i.branch = { .imm = imm32,
+                            .addr = u32(out_inst.addr + 4u + imm32),
+                            .cc = cc };
     }
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0xE000u) { // 4.6.12 B, T2 encoding (pg 4-38)
-    u32 const imm32{u32(sext((w0 & 0x7FFu) << 1u, 11u))};
+  if ((w0 & 0xF800u) == 0xE000u) {  // 4.6.12 B, T2 encoding (pg 4-38)
+    u32 const imm32{ u32(sext((w0 & 0x7FFu) << 1u, 11u)) };
     out_inst.type = inst_type::BRANCH;
-    out_inst.i.branch = {  .imm = imm32, .addr = u32(out_inst.addr + 4u + imm32),
-      .cc = cond_code::AL2 };
+    out_inst.i.branch = { .imm = imm32,
+                          .addr = u32(out_inst.addr + 4u + imm32),
+                          .cc = cond_code::AL2 };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4380u) { // 4.6.16 BIC (reg), T1 encoding (pg 4-46)
-    u8 const dn{u8(w0 & 7u)};
+  if ((w0 & 0xFFC0u) == 0x4380u) {  // 4.6.16 BIC (reg), T1 encoding (pg 4-46)
+    u8 const dn{ u8(w0 & 7u) };
     out_inst.type = inst_type::BIT_CLEAR_REG;
     out_inst.dr = u16(1u << dn);
-    out_inst.i.bit_clear_reg = { .shift = decode_imm_shift(0b00, 0), .n = dn,
-      .m = u8((w0 >> 3u) & 7u) };
+    out_inst.i.bit_clear_reg = { .shift = decode_imm_shift(0b00, 0),
+                                 .n = dn,
+                                 .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFF00u) == 0xBE00u) { // 4.6.17 BKPT, T1 encoding (pg 4-48)
+  if ((w0 & 0xFF00u) == 0xBE00u) {  // 4.6.17 BKPT, T1 encoding (pg 4-48)
     out_inst.type = inst_type::BREAKPOINT;
     out_inst.i.breakpoint = { .imm = u16(w0 & 0xFFu) };
     return true;
   }
 
-  if ((w0 & 0xFF80u) == 0x4780u) { // 4.6.19 BLX (reg), T1 encoding (pg 4-52)
+  if ((w0 & 0xFF80u) == 0x4780u) {  // 4.6.19 BLX (reg), T1 encoding (pg 4-52)
     out_inst.type = inst_type::BRANCH_LINK_XCHG_REG;
     out_inst.i.branch_link_xchg_reg = { .reg = u8((w0 >> 3u) & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFF80u) == 0x4700u) { // 4.6.20 BX, T1 encoding (pg 4-54)
+  if ((w0 & 0xFF80u) == 0x4700u) {  // 4.6.20 BX, T1 encoding (pg 4-54)
     out_inst.type = inst_type::BRANCH_XCHG;
-    out_inst.i.branch_xchg = { .m = u8((w0 >> 3u) & 0xFu)};
+    out_inst.i.branch_xchg = { .m = u8((w0 >> 3u) & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFD00u) == 0xB900u) { // 4.6.22 CBNZ, T1 encoding (pg 4-58)
-    u32 const imm5{(w0 >> 3u) & 0x1Fu}, i{(w0 >> 9u) & 1u}, imm32{(imm5 << 1u) | (i << 6u)};
+  if ((w0 & 0xFD00u) == 0xB900u) {  // 4.6.22 CBNZ, T1 encoding (pg 4-58)
+    u32 const imm5{ (w0 >> 3u) & 0x1Fu }, i{ (w0 >> 9u) & 1u },
+        imm32{ (imm5 << 1u) | (i << 6u) };
     out_inst.type = inst_type::CBNZ;
-    out_inst.i.cmp_branch_nz = { .addr = out_inst.addr + 4u + imm32, .n = u8(w0 & 7u),
-      .imm = u8(imm32) };
+    out_inst.i.cmp_branch_nz = { .addr = out_inst.addr + 4u + imm32,
+                                 .n = u8(w0 & 7u),
+                                 .imm = u8(imm32) };
     return true;
   }
 
-  if ((w0 & 0xFD00u) == 0xB100u) { // 4.6.23 CBZ, T1 encoding (pg 4-60)
-    u32 const imm5{(w0 >> 3u) & 0x1Fu}, i{(w0 >> 9u) & 1u}, imm32{(imm5 << 1u) | (i << 6u)};
+  if ((w0 & 0xFD00u) == 0xB100u) {  // 4.6.23 CBZ, T1 encoding (pg 4-60)
+    u32 const imm5{ (w0 >> 3u) & 0x1Fu }, i{ (w0 >> 9u) & 1u },
+        imm32{ (imm5 << 1u) | (i << 6u) };
     out_inst.type = inst_type::CBZ;
-    out_inst.i.cmp_branch_z = { .addr = out_inst.addr + 4u + imm32, .n = u8(w0 & 7u),
-      .imm = u8(imm32) };
+    out_inst.i.cmp_branch_z = { .addr = out_inst.addr + 4u + imm32,
+                                .n = u8(w0 & 7u),
+                                .imm = u8(imm32) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x2800u) { // 4.6.29 CMP (imm), T1 encoding (pg 4-72)
+  if ((w0 & 0xF800u) == 0x2800u) {  // 4.6.29 CMP (imm), T1 encoding (pg 4-72)
     out_inst.type = inst_type::CMP_IMM;
     out_inst.i.cmp_imm = { .imm = u8(w0 & 0xFFu), .n = u8((w0 >> 8u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4280u) { // 4.6.30 CMP (reg), T1 encoding (pg 4-74)
+  if ((w0 & 0xFFC0u) == 0x4280u) {  // 4.6.30 CMP (reg), T1 encoding (pg 4-74)
     out_inst.type = inst_type::CMP_REG;
     out_inst.i.cmp_reg = { .shift = decode_imm_shift(0b00, 0),
-      .n = u8(w0 & 7u), .m = u8((w0 >> 3u) & 7u) };
+                           .n = u8(w0 & 7u),
+                           .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFF00u) == 0x4500u) { // 4.6.30 CMP (reg), T2 encoding (pg 4-74)
+  if ((w0 & 0xFF00u) == 0x4500u) {  // 4.6.30 CMP (reg), T2 encoding (pg 4-74)
     out_inst.type = inst_type::CMP_REG;
     out_inst.i.cmp_reg = { .shift = decode_imm_shift(0b00, 0),
-      .n = u8((w0 & 7u) | ((w0 >> 4u) & 8u)), .m = u8((w0 >> 3u) & 0xFu) };
+                           .n = u8((w0 & 7u) | ((w0 >> 4u) & 8u)),
+                           .m = u8((w0 >> 3u) & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFFE8u) == 0xB660u) { // 4.6.31 CPS, T1 encoding (pg 4-76)
-    u8 const im{u8((w0 >> 4u) & 1u)};
+  if ((w0 & 0xFFE8u) == 0xB660u) {  // 4.6.31 CPS, T1 encoding (pg 4-76)
+    u8 const im{ u8((w0 >> 4u) & 1u) };
     out_inst.type = inst_type::CHANGE_PROC_STATE;
-    out_inst.i.change_proc_state = { .en = (im == 0), .dis = (im == 1), .cm = 0,
-      .aff_a = u8((w0 >> 2u) & 1u), .aff_i = u8((w0 >> 1u) & 1u), .aff_f = u8(w0 & 1u) };
+    out_inst.i.change_proc_state = { .en = (im == 0),
+                                     .dis = (im == 1),
+                                     .cm = 0,
+                                     .aff_a = u8((w0 >> 2u) & 1u),
+                                     .aff_i = u8((w0 >> 1u) & 1u),
+                                     .aff_f = u8(w0 & 1u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4040u) { // 4.6.37 EOR (reg), T1 encoding (pg 4-88)
-    u8 const rdn{u8(w0 & 7u)};
+  if ((w0 & 0xFFC0u) == 0x4040u) {  // 4.6.37 EOR (reg), T1 encoding (pg 4-88)
+    u8 const rdn{ u8(w0 & 7u) };
     out_inst.type = inst_type::EXCL_OR_REG;
     out_inst.dr = u16(1u << rdn);
-    out_inst.i.excl_or_reg = { .shift = decode_imm_shift(0b00, 0), .n = rdn,
-      .m = u8((w0 >> 3u) & 7u) };
+    out_inst.i.excl_or_reg = { .shift = decode_imm_shift(0b00, 0),
+                               .n = rdn,
+                               .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFF00u) == 0xBF00u) { // 4.6.39 IT, T1 encoding (pg 4-92)
-    u8 const mask{u8(w0 & 0xFu)};
-    if (mask == 0) { // T1 encoding note: '0000' = nop-compatible hint
-      out_inst.type = inst_type::NOP; out_inst.i.nop = {};
+  if ((w0 & 0xFF00u) == 0xBF00u) {  // 4.6.39 IT, T1 encoding (pg 4-92)
+    u8 const mask{ u8(w0 & 0xFu) };
+    if (mask == 0) {  // T1 encoding note: '0000' = nop-compatible hint
+      out_inst.type = inst_type::NOP;
+      out_inst.i.nop = {};
       return true;
     }
     u8 cnt = 4u, tmp = mask;
-    while (!(tmp & 1u)) { tmp >>= 1u; --cnt; }
+    while (!(tmp & 1u)) {
+      tmp >>= 1u;
+      --cnt;
+    }
     out_inst.type = inst_type::IF_THEN;
     out_inst.i.if_then = { .firstcond = u8((w0 >> 4u) & 0xFu), .mask = mask, .cnt = cnt };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0xC800u) { // 4.6.42 LDMIA, T1 encoding (pg 4-98)
-    u8 const n{u8((w0 >> 8u) & 7u)};
+  if ((w0 & 0xF800u) == 0xC800u) {  // 4.6.42 LDMIA, T1 encoding (pg 4-98)
+    u8 const n{ u8((w0 >> 8u) & 7u) };
     out_inst.type = inst_type::LOAD_MULT_INC_AFTER;
     out_inst.dr = u16(w0 & 0xFFu);
     out_inst.i.load_mult_inc_after = { .n = n, .wback = !(out_inst.dr & (1u << n)) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x6800u) { // 4.6.43 LDR (imm), T1 encoding (pg 4-100)
+  if ((w0 & 0xF800u) == 0x6800u) {  // 4.6.43 LDR (imm), T1 encoding (pg 4-100)
     out_inst.type = inst_type::LOAD_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.load_imm = { .imm = u16(((w0 >> 6u) & 0x1Fu) << 2u),
-      .n = u8((w0 >> 3u) & 7u), .add = 1u, .index = 1u };
+                            .n = u8((w0 >> 3u) & 7u),
+                            .add = 1u,
+                            .index = 1u };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x9800u) { // 4.6.43 LDR (imm), T2 encoding (pg 4-100)
+  if ((w0 & 0xF800u) == 0x9800u) {  // 4.6.43 LDR (imm), T2 encoding (pg 4-100)
     out_inst.type = inst_type::LOAD_IMM;
     out_inst.dr = u16(1u << ((w0 >> 8u) & 7u));
-    out_inst.i.load_imm = { .imm = u16((w0 & 0xFFu) << 2u), .n = 13u,
-      .add = 1u, .index = 1u };
+    out_inst.i.load_imm = { .imm = u16((w0 & 0xFFu) << 2u),
+                            .n = 13u,
+                            .add = 1u,
+                            .index = 1u };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x4800u) { // 4.6.44 LDR (literal), T1 encoding (pg 4-102)
-    u16 const imm{u16((w0 & 0xFFu) << 2u)};
+  if ((w0 & 0xF800u) == 0x4800u) {  // 4.6.44 LDR (literal), T1 encoding (pg 4-102)
+    u16 const imm{ u16((w0 & 0xFFu) << 2u) };
     out_inst.type = inst_type::LOAD_LIT;
     out_inst.dr = u16(1u << ((w0 >> 8u) & 7u));
-    out_inst.i.load_lit = { .imm = imm, .addr = u32(inst_align(out_inst.addr, 4) + imm + 4),
-      .add = 1u };
+    out_inst.i.load_lit = { .imm = imm,
+                            .addr = u32(inst_align(out_inst.addr, 4) + imm + 4),
+                            .add = 1u };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x5800u) { // 4.6.45 LDR (register), T1 encoding (pg 4-104)
+  if ((w0 & 0xFE00u) == 0x5800u) {  // 4.6.45 LDR (register), T1 encoding (pg 4-104)
     out_inst.type = inst_type::LOAD_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
-    out_inst.i.load_reg = { .shift = decode_imm_shift(0b00, 0), .n = u8((w0 >> 3u) & 7u),
-      .m = u8((w0 >> 6u) & 7u) };
+    out_inst.i.load_reg = { .shift = decode_imm_shift(0b00, 0),
+                            .n = u8((w0 >> 3u) & 7u),
+                            .m = u8((w0 >> 6u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x7800u) { // 4.6.46 LDRB (imm), T1 encoding (pg 4-106)
+  if ((w0 & 0xF800u) == 0x7800u) {  // 4.6.46 LDRB (imm), T1 encoding (pg 4-106)
     out_inst.type = inst_type::LOAD_BYTE_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
-    out_inst.i.load_byte_imm = { .imm = u8((w0 >> 6u) & 0x1Fu), .n = u8((w0 >> 3u) & 7u),
-      .add = 1u, .index = 1u };
+    out_inst.i.load_byte_imm = { .imm = u8((w0 >> 6u) & 0x1Fu),
+                                 .n = u8((w0 >> 3u) & 7u),
+                                 .add = 1u,
+                                 .index = 1u };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x5C00u) { // 4.6.48 LDRB (reg), T1 encoding (pg 4-110)
+  if ((w0 & 0xFE00u) == 0x5C00u) {  // 4.6.48 LDRB (reg), T1 encoding (pg 4-110)
     out_inst.type = inst_type::LOAD_BYTE_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.load_byte_reg = { .shift = decode_imm_shift(0b00, 0),
-      .n = u8((w0 >> 3u) & 7u), .m = u8((w0 >> 6u) & 7u) };
+                                 .n = u8((w0 >> 3u) & 7u),
+                                 .m = u8((w0 >> 6u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x8800u) { // 4.6.55 LDRH (imm), T1 encoding (pg 4-124)
+  if ((w0 & 0xF800u) == 0x8800u) {  // 4.6.55 LDRH (imm), T1 encoding (pg 4-124)
     out_inst.type = inst_type::LOAD_HALF_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.load_half_imm = { .imm = (u8)(((w0 >> 6u) & 0x1Fu) << 1u),
-      .n = u8((w0 >> 3u) & 7u), .add = 1u, .index = 1u };
+                                 .n = u8((w0 >> 3u) & 7u),
+                                 .add = 1u,
+                                 .index = 1u };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x5A00u) { // 4.6.57 LDRH (reg), T1 encoding (pg 4-128)
+  if ((w0 & 0xFE00u) == 0x5A00u) {  // 4.6.57 LDRH (reg), T1 encoding (pg 4-128)
     out_inst.type = inst_type::LOAD_HALF_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.load_half_reg = { .shift = decode_imm_shift(0b00, 0),
-      .n = u8((w0 >> 3u) & 7u), .m = u8((w0 >> 6u) & 7u) };
+                                 .n = u8((w0 >> 3u) & 7u),
+                                 .m = u8((w0 >> 6u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x5600u) { // 4.6.61 LDRSB (reg), T1 encoding (pg 4-136)
+  if ((w0 & 0xFE00u) == 0x5600u) {  // 4.6.61 LDRSB (reg), T1 encoding (pg 4-136)
     out_inst.type = inst_type::LOAD_SIGNED_BYTE_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.load_signed_byte_reg = { .shift = decode_imm_shift(0b00, 0),
-       .n = u8((w0 >> 3u) & 7u), .m = u8((w0 >> 6u) & 7u) };
+                                        .n = u8((w0 >> 3u) & 7u),
+                                        .m = u8((w0 >> 6u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x5E00u) { // 4.6.65 LDRSH (reg), T1 encoding (pg 4-144)
+  if ((w0 & 0xFE00u) == 0x5E00u) {  // 4.6.65 LDRSH (reg), T1 encoding (pg 4-144)
     out_inst.type = inst_type::LOAD_SIGNED_HALF_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.load_signed_half_reg = { .shift = decode_imm_shift(0b00, 0),
-       .n = u8((w0 >> 3u) & 7u), .m = u8((w0 >> 6u) & 7u) };
+                                        .n = u8((w0 >> 3u) & 7u),
+                                        .m = u8((w0 >> 6u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0) { // 4.6.68 LSL (imm), T1 encoding (pg 4-150)
+  if ((w0 & 0xF800u) == 0) {  // 4.6.68 LSL (imm), T1 encoding (pg 4-150)
     out_inst.type = inst_type::LSHIFT_LOG_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.lshift_log_imm = { .shift = decode_imm_shift(0b00, u8((w0 >> 6u) & 0x1Fu)),
-      .m = u8((w0 >> 3u) & 7u) };
+                                  .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4080u) { // 4.6.69 LSL (reg), T1 encoding (pg 4-152)
-    u8 const dn{u8(w0 & 7u)};
+  if ((w0 & 0xFFC0u) == 0x4080u) {  // 4.6.69 LSL (reg), T1 encoding (pg 4-152)
+    u8 const dn{ u8(w0 & 7u) };
     out_inst.type = inst_type::LSHIFT_LOG_REG;
     out_inst.dr = dn;
     out_inst.i.lshift_log_reg = { .n = dn, .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x800u) { // 4.6.70 LSR (imm), T1 encoding (pg 4-154)
+  if ((w0 & 0xF800u) == 0x800u) {  // 4.6.70 LSR (imm), T1 encoding (pg 4-154)
     out_inst.type = inst_type::RSHIFT_LOG_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.rshift_log_imm = { .shift = decode_imm_shift(0b01, u8((w0 >> 6u) & 0x1Fu)),
-      .m = u8((w0 >> 3u) & 7u) };
+                                  .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x40C0u) { // 4.6.71 LSR (reg), T1 encoding (pg 4-156)
-    u8 const rdn{u8(w0 & 7u)};
+  if ((w0 & 0xFFC0u) == 0x40C0u) {  // 4.6.71 LSR (reg), T1 encoding (pg 4-156)
+    u8 const rdn{ u8(w0 & 7u) };
     out_inst.type = inst_type::RSHIFT_LOG_REG;
     out_inst.dr = u16(1u << rdn);
     out_inst.i.rshift_log_reg = { .n = rdn, .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x2000u) { // 4.6.76 MOV (imm), T1 encoding (pg 4-166)
+  if ((w0 & 0xF800u) == 0x2000u) {  // 4.6.76 MOV (imm), T1 encoding (pg 4-166)
     out_inst.type = inst_type::MOV_IMM;
     out_inst.dr = u16(1u << ((w0 >> 8u) & 7u));
     out_inst.i.mov_imm = { .imm = u8(w0 & 0xFFu) };
     return true;
   }
 
-  if ((w0 & 0xFF00u) == 0x4600u) { // 4.6.77 MOV (reg), T1 encoding (pg 4-168)
+  if ((w0 & 0xFF00u) == 0x4600u) {  // 4.6.77 MOV (reg), T1 encoding (pg 4-168)
     out_inst.type = inst_type::MOV_REG;
     out_inst.dr = u16(1u << ((w0 & 7u) | ((w0 & 0x80u) >> 4u)));
     out_inst.i.mov_reg = { .m = u8((w0 >> 3u) & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4340u) { // 4.6.84 MUL, T1 encoding (pg 4-181)
+  if ((w0 & 0xFFC0u) == 0x4340u) {  // 4.6.84 MUL, T1 encoding (pg 4-181)
     out_inst.type = inst_type::MUL;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.mul = { .n = u8((w0 >> 3u) & 7u), .m = u8(w0 & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x43C0u) { // 4.6.86 MVN (reg), T1 encoding (pg 4-185)
+  if ((w0 & 0xFFC0u) == 0x43C0u) {  // 4.6.86 MVN (reg), T1 encoding (pg 4-185)
     out_inst.type = inst_type::MOV_NEG_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.mov_neg_reg = { .shift = decode_imm_shift(0, 0), .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if (w0 == 0xBF00u) { // 4.6.88 NOP (pg 4-189)
-    out_inst.type = inst_type::NOP; out_inst.i.nop = {};
+  if (w0 == 0xBF00u) {  // 4.6.88 NOP (pg 4-189)
+    out_inst.type = inst_type::NOP;
+    out_inst.i.nop = {};
     return true;
   }
 
-  if ((w0 & 0xFFC0) == 0x4300) { // 4.6.92 ORR (reg), T1 encoding (pg 4-197)
+  if ((w0 & 0xFFC0) == 0x4300) {  // 4.6.92 ORR (reg), T1 encoding (pg 4-197)
     out_inst.type = inst_type::OR_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
-    out_inst.i.or_reg = { .shift = decode_imm_shift(0b00, 0), .n = u8(w0 & 7u),
-      .m = u8((w0 >> 3u) & 7u) };
+    out_inst.i.or_reg = { .shift = decode_imm_shift(0b00, 0),
+                          .n = u8(w0 & 7u),
+                          .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0xBC00u) { // 4.6.98 POP, T1 encoding (pg 4-209)
+  if ((w0 & 0xFE00u) == 0xBC00u) {  // 4.6.98 POP, T1 encoding (pg 4-209)
     out_inst.type = inst_type::POP;
     out_inst.dr = u16(((w0 & 0x100u) << 7) | (w0 & 0xFFu));
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0xB400u) { // 4.6.99 PUSH, T1 encoding (pg 4-211)
+  if ((w0 & 0xFE00u) == 0xB400u) {  // 4.6.99 PUSH, T1 encoding (pg 4-211)
     out_inst.type = inst_type::PUSH;
     out_inst.i.push = { .reg_list = u16(((w0 & 0x0100u) << 6u) | (w0 & 0xFFu)) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0xBA00u) { // 4.6.111 REV, T1 encoding (pg 4-235)
+  if ((w0 & 0xFFC0u) == 0xBA00u) {  // 4.6.111 REV, T1 encoding (pg 4-235)
     out_inst.type = inst_type::BYTE_REV_WORD;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.byte_rev_word = { .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0xBA40u) { // 4.6.112 REV16, T1 encoding (pg 4-237)
+  if ((w0 & 0xFFC0u) == 0xBA40u) {  // 4.6.112 REV16, T1 encoding (pg 4-237)
     out_inst.type = inst_type::BYTE_REV_PACKED_HALF;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.byte_rev_packed_half = { .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0xBAC0u) { // 4.6.113 REVSH, T1 encoding (pg 4-239)
+  if ((w0 & 0xFFC0u) == 0xBAC0u) {  // 4.6.113 REVSH, T1 encoding (pg 4-239)
     out_inst.type = inst_type::BYTE_REV_SIGNED_HALF;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.byte_rev_signed_half = { .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4240u) { // 4.6.118 RSB (imm), T1 encoding (pg 4-249)
+  if ((w0 & 0xFFC0u) == 0x4240u) {  // 4.6.118 RSB (imm), T1 encoding (pg 4-249)
     out_inst.type = inst_type::SUB_REV_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.sub_rev_imm = { .imm = 0, .n = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4180u) { // 4.6.124 SBC (reg), T1 encoding (pg 4-261)
-    u8 const rdn{u8(w0 & 7u)};
+  if ((w0 & 0xFFC0u) == 0x4180u) {  // 4.6.124 SBC (reg), T1 encoding (pg 4-261)
+    u8 const rdn{ u8(w0 & 7u) };
     out_inst.type = inst_type::SUB_REG_CARRY;
     out_inst.dr = u16(1u << rdn);
-    out_inst.i.sub_reg_carry = { .shift = decode_imm_shift(0, 0), .n = rdn,
-      .m = u8((w0 >> 3u) & 7u) };
+    out_inst.i.sub_reg_carry = { .shift = decode_imm_shift(0, 0),
+                                 .n = rdn,
+                                 .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0xC000u) { // 4.6.161 STMIA, T1 encoding (pg 4-335)
+  if ((w0 & 0xF800u) == 0xC000u) {  // 4.6.161 STMIA, T1 encoding (pg 4-335)
     out_inst.type = inst_type::STORE_MULT_INC_AFTER;
-    out_inst.i.store_mult_inc_after = { .regs = u8(w0 & 0xFFu), .n = u8((w0 >> 8u) & 7u),
-      .wback = 1u };
+    out_inst.i.store_mult_inc_after = { .regs = u8(w0 & 0xFFu),
+                                        .n = u8((w0 >> 8u) & 7u),
+                                        .wback = 1u };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x6000u) { // 4.6.162 STR (imm), T1 encoding (pg 4-337)
+  if ((w0 & 0xF800u) == 0x6000u) {  // 4.6.162 STR (imm), T1 encoding (pg 4-337)
     out_inst.type = inst_type::STORE_IMM;
-    out_inst.i.store_imm = { .imm = u16(((w0 >> 6u) & 0x1Fu) << 2u), .t = u8(w0 & 7u),
-      .n = u8((w0 >> 3u) & 7u) };
+    out_inst.i.store_imm = { .imm = u16(((w0 >> 6u) & 0x1Fu) << 2u),
+                             .t = u8(w0 & 7u),
+                             .n = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x9000u) { // 4.6.162 STR (imm), T2 encoding (pg 4-337)
+  if ((w0 & 0xF800u) == 0x9000u) {  // 4.6.162 STR (imm), T2 encoding (pg 4-337)
     out_inst.type = inst_type::STORE_IMM;
-    out_inst.i.store_imm = { .imm = u16((w0 & 0xFFu) << 2u), .t = u8((w0 >> 8u) & 7u),
-      .n = reg::SP };
+    out_inst.i.store_imm = { .imm = u16((w0 & 0xFFu) << 2u),
+                             .t = u8((w0 >> 8u) & 7u),
+                             .n = reg::SP };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x5000u) { // 4.6.163 STR (reg), T1 encoding (pg 4-339)
+  if ((w0 & 0xFE00u) == 0x5000u) {  // 4.6.163 STR (reg), T1 encoding (pg 4-339)
     out_inst.type = inst_type::STORE_REG;
-    out_inst.i.store_reg = { .shift = decode_imm_shift(0b00, 0), .t = u8(w0 & 7u),
-      .n = u8((w0 >> 3u) & 7u), .m = u8((w0 >> 6u) & 7u) };
+    out_inst.i.store_reg = { .shift = decode_imm_shift(0b00, 0),
+                             .t = u8(w0 & 7u),
+                             .n = u8((w0 >> 3u) & 7u),
+                             .m = u8((w0 >> 6u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x7000u) { // 4.6.164 STRB (imm), T1 encoding (pg 4-341)
+  if ((w0 & 0xF800u) == 0x7000u) {  // 4.6.164 STRB (imm), T1 encoding (pg 4-341)
     out_inst.type = inst_type::STORE_BYTE_IMM;
-    out_inst.i.store_byte_imm = { .imm = u16((w0 >> 6u) & 0x1Fu), .n = u8((w0 >> 3u) & 7u),
-      .t = u8(w0 & 7u), .index = 1u, .add = 1u };
+    out_inst.i.store_byte_imm = { .imm = u16((w0 >> 6u) & 0x1Fu),
+                                  .n = u8((w0 >> 3u) & 7u),
+                                  .t = u8(w0 & 7u),
+                                  .index = 1u,
+                                  .add = 1u };
     return true;
   }
 
   if ((w0 & 0xFE00u) == 0x5400u) {  // 4.6.165 STRB (reg), T1 encoding (pg 4-343)
     out_inst.type = inst_type::STORE_BYTE_REG;
-    out_inst.i.store_byte_reg = { .shift = decode_imm_shift(0b00, 0), .t = u8(w0 & 7u),
-      .m = u8((w0 >> 6u) & 7u), .n = u8((w0 >> 3u) & 7u) };
+    out_inst.i.store_byte_reg = { .shift = decode_imm_shift(0b00, 0),
+                                  .t = u8(w0 & 7u),
+                                  .m = u8((w0 >> 6u) & 7u),
+                                  .n = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x8000u) { // 4.6.172 STRH (imm), T1 encoding (pg 4-357)
+  if ((w0 & 0xF800u) == 0x8000u) {  // 4.6.172 STRH (imm), T1 encoding (pg 4-357)
     out_inst.type = inst_type::STORE_HALF_IMM;
-    out_inst.i.store_half_imm = { .imm = u16(((w0 >> 6u) & 0x1F) << 1u), .t = u8(w0 & 7u),
-      .n = u8((w0 >> 3u) & 7u), .index = 1u, .add = 1u };
+    out_inst.i.store_half_imm = { .imm = u16(((w0 >> 6u) & 0x1F) << 1u),
+                                  .t = u8(w0 & 7u),
+                                  .n = u8((w0 >> 3u) & 7u),
+                                  .index = 1u,
+                                  .add = 1u };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x5200u) { // 4.6.173 STRG (reg), T1 encoding (pg 4-359)
+  if ((w0 & 0xFE00u) == 0x5200u) {  // 4.6.173 STRG (reg), T1 encoding (pg 4-359)
     out_inst.type = inst_type::STORE_HALF_REG;
-    out_inst.i.store_half_reg = { .shift = decode_imm_shift(0b00, 0), .t = u8(w0 & 7u),
-      .n = u8((w0 >> 3u) & 7u), .m = u8((w0 >> 6u) & 3u) };
+    out_inst.i.store_half_reg = { .shift = decode_imm_shift(0b00, 0),
+                                  .t = u8(w0 & 7u),
+                                  .n = u8((w0 >> 3u) & 7u),
+                                  .m = u8((w0 >> 6u) & 3u) };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x1E00u) { // 4.6.176 SUB (imm), T1 encoding (pg 4-365)
+  if ((w0 & 0xFE00u) == 0x1E00u) {  // 4.6.176 SUB (imm), T1 encoding (pg 4-365)
     out_inst.type = inst_type::SUB_IMM;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.sub_imm = { .imm = (w0 >> 6u) & 7u, .n = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xF800u) == 0x3800u) { // 4.6.176 SUB (imm), T2 encoding (pg 4-365)
+  if ((w0 & 0xF800u) == 0x3800u) {  // 4.6.176 SUB (imm), T2 encoding (pg 4-365)
     out_inst.type = inst_type::SUB_IMM;
     out_inst.dr = u16(1u << ((w0 >> 8u) & 7u));
     out_inst.i.sub_imm = { .imm = w0 & 0xFFu, .n = u8((w0 >> 8u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFE00u) == 0x1A00u) { // 4.6.177 SUB (reg), T1 encoding (pg 4-367)
+  if ((w0 & 0xFE00u) == 0x1A00u) {  // 4.6.177 SUB (reg), T1 encoding (pg 4-367)
     out_inst.type = inst_type::SUB_REG;
     out_inst.dr = u16(1u << (w0 & 7u));
-    out_inst.i.sub_reg = { .shift = decode_imm_shift(0, 0), .n = u8((w0 >> 3u) & 7u),
-      .m = u8((w0 >> 6u) & 7u) };
+    out_inst.i.sub_reg = { .shift = decode_imm_shift(0, 0),
+                           .n = u8((w0 >> 3u) & 7u),
+                           .m = u8((w0 >> 6u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFF80u) == 0xB080u) { // 4.6.178 SUB (SP - imm), T1 encoding (pg 4-369)
+  if ((w0 & 0xFF80u) == 0xB080u) {  // 4.6.178 SUB (SP - imm), T1 encoding (pg 4-369)
     out_inst.type = inst_type::SUB_SP_IMM;
     out_inst.dr = u16(1u << 13);
     out_inst.i.sub_sp_imm = { .imm = (w0 & 0x7Fu) << 2u };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0xB240u) { // 4.6.185 SXTB, T1 encoding (pg 4-383)
+  if ((w0 & 0xFFC0u) == 0xB240u) {  // 4.6.185 SXTB, T1 encoding (pg 4-383)
     out_inst.type = inst_type::EXTEND_SIGNED_BYTE;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.extend_signed_byte = { .m = u8((w0 >> 3u) & 7u), .rotation = 0 };
@@ -600,21 +671,22 @@ bool decode_16bit_inst(u16 const w0, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0x4200u) { // 4.6.193 TST, T1 encoding (pg 4-399)
+  if ((w0 & 0xFFC0u) == 0x4200u) {  // 4.6.193 TST, T1 encoding (pg 4-399)
     out_inst.type = inst_type::TEST_REG;
-    out_inst.i.test_reg = { .shift = decode_imm_shift(0b00, 0), .n = u8(w0 & 7u),
-      .m = u8((w0 >> 3u) & 7u) };
+    out_inst.i.test_reg = { .shift = decode_imm_shift(0b00, 0),
+                            .n = u8(w0 & 7u),
+                            .m = u8((w0 >> 3u) & 7u) };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0xB2C0u) { // 4.6.224 UXTB, T1 encoding (pg 4-461)
+  if ((w0 & 0xFFC0u) == 0xB2C0u) {  // 4.6.224 UXTB, T1 encoding (pg 4-461)
     out_inst.type = inst_type::EXTEND_UNSIGNED_BYTE;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.extend_unsigned_byte = { .m = u8((w0 >> 3u) & 7u), .rotation = 0 };
     return true;
   }
 
-  if ((w0 & 0xFFC0u) == 0xB280u) { // 4.6.226 UXTH, T1 encoding (pg 4-465)
+  if ((w0 & 0xFFC0u) == 0xB280u) {  // 4.6.226 UXTH, T1 encoding (pg 4-465)
     out_inst.type = inst_type::EXTEND_UNSIGNED_HALF;
     out_inst.dr = u16(1u << (w0 & 7u));
     out_inst.i.extend_unsigned_half = { .m = u8((w0 >> 3u) & 7u), .rotation = 0 };
@@ -629,31 +701,31 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.1 ADC (imm), T1 encoding (pg 4-16)
   if (((w0 & 0xFBE0u) == 0xF140u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u};
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u };
     out_inst.type = inst_type::ADD_CARRY_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.add_carry_imm = { .imm = decode_imm12((i << 11u) | (imm3 << 8u) | imm8),
-      .n = u8(w0 & 0xFu) };
+                                 .n = u8(w0 & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFFE0u) == 0xEB40u) { // 4.6.2 ADC (reg), T2 encoding (pg 4-18)
-    u8 const imm3{u8((w1 >> 12u) & 7u)}, imm2{u8((w1 >> 6u) & 3u)};
+  if ((w0 & 0xFFE0u) == 0xEB40u) {  // 4.6.2 ADC (reg), T2 encoding (pg 4-18)
+    u8 const imm3{ u8((w1 >> 12u) & 7u) }, imm2{ u8((w1 >> 6u) & 3u) };
     out_inst.type = inst_type::ADD_CARRY_REG;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
-    out_inst.i.add_carry_reg = {
-      .shift = decode_imm_shift(u8((w1 >> 4u) & 3u), u8((imm3 << 2u) | imm2)),
-      .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+    out_inst.i.add_carry_reg = { .shift = decode_imm_shift(u8((w1 >> 4u) & 3u),
+                                                           u8((imm3 << 2u) | imm2)),
+                                 .n = u8(w0 & 0xFu),
+                                 .m = u8(w1 & 0xFu) };
     return true;
   }
 
   // 4.6.3 ADD (imm), T3 encoding (pg 4-20)
   if (((w0 & 0xFBE0u) == 0xF100u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 0x7u}, i{(w0 >> 10u) & 1u},
-      imm{decode_imm12((i << 11u) | (imm3 << 8u) | imm8)};
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, s{u8((w0 >> 4u) & 1u)},
-      n{u8(w0 & 0xFu)};
-    if ((s == 1) && (d == 15)) { // 4.6.27 CMN (imm), T1 encoding (pg 4-68)
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 0x7u }, i{ (w0 >> 10u) & 1u },
+        imm{ decode_imm12((i << 11u) | (imm3 << 8u) | imm8) };
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, s{ u8((w0 >> 4u) & 1u) }, n{ u8(w0 & 0xFu) };
+    if ((s == 1) && (d == 15)) {  // 4.6.27 CMN (imm), T1 encoding (pg 4-68)
       out_inst.type = inst_type::CMP_NEG_IMM;
       out_inst.i.cmp_neg_imm = { .imm = imm, .n = n };
       return true;
@@ -666,14 +738,14 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.3 ADD (imm), T4 encoding (pg 4-20)
   if (((w0 & 0xFBF0u) == 0xF200u) && ((w1 & 0x8000u) == 0)) {
-    u8 const n{u8(w0 & 0xFu)}, d{u8((w1 >> 8u) & 0xFu)};
-    u32 const i{(w0 >> 10u) & 1u}, imm3{(w1 >> 12u) & 7u}, imm8{w1 & 0xFFu},
-      imm{(i << 11u) | (imm3 << 8u) | imm8};
+    u8 const n{ u8(w0 & 0xFu) }, d{ u8((w1 >> 8u) & 0xFu) };
+    u32 const i{ (w0 >> 10u) & 1u }, imm3{ (w1 >> 12u) & 7u }, imm8{ w1 & 0xFFu },
+        imm{ (i << 11u) | (imm3 << 8u) | imm8 };
     if (n == 15) {
       NL_LOG_ERR("SEE ADR on page 4-28");
       return false;
     }
-    if (n == 13) { // 4.6.5 ADD (SP plus imm), T4 encoding (pg 4-24)
+    if (n == 13) {  // 4.6.5 ADD (SP plus imm), T4 encoding (pg 4-24)
       out_inst.type = inst_type::ADD_SP_IMM;
       out_inst.dr = u16(1u << d);
       out_inst.i.add_sp_imm = { .imm = u16(imm) };
@@ -685,14 +757,15 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFFE0u) == 0xEB00u) { // 4.6.4 ADD (reg), T3 encoding (pg 4-22)
-    u32 const imm3{(w1 >> 12u) & 7u}, imm2{(w1 >> 6u) & 3u};
-    u8 const n{u8(w0 & 0xFu)}, s{u8((w0 >> 4u) & 1u)}, m{u8(w1 & 0xFu)},
-      d{u8((w1 >> 8u) & 0xFu)}, type{u8((w1 >> 4u) & 3u)}, si{u8((imm3 << 2u) | imm2)};
-    if ((s == 1u) && (d == reg::PC)) { // CMN (reg) pg 4-70
+  if ((w0 & 0xFFE0u) == 0xEB00u) {  // 4.6.4 ADD (reg), T3 encoding (pg 4-22)
+    u32 const imm3{ (w1 >> 12u) & 7u }, imm2{ (w1 >> 6u) & 3u };
+    u8 const n{ u8(w0 & 0xFu) }, s{ u8((w0 >> 4u) & 1u) }, m{ u8(w1 & 0xFu) },
+        d{ u8((w1 >> 8u) & 0xFu) }, type{ u8((w1 >> 4u) & 3u) },
+        si{ u8((imm3 << 2u) | imm2) };
+    if ((s == 1u) && (d == reg::PC)) {  // CMN (reg) pg 4-70
       return false;
     }
-    if (n == u8(reg::SP)) { // ADD (SP + reg), T3 encoding (pg 4-26)
+    if (n == u8(reg::SP)) {  // ADD (SP + reg), T3 encoding (pg 4-26)
       out_inst.type = inst_type::ADD_SP_REG;
       out_inst.dr = u16(1u << d);
       out_inst.i.add_sp_reg = { .shift = decode_imm_shift(type, si), .m = m };
@@ -706,51 +779,56 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.8 AND (imm), T1 encoding (pg 4-30)
   if (((w0 & 0xFBE0u) == 0xF000u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u};
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u };
     out_inst.type = inst_type::AND_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.and_imm = { .imm = decode_imm12((i << 11u) | (imm3 << 8u) | imm8),
-      .n = u8(w0 & 0xFu) };
+                           .n = u8(w0 & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFFE0u) == 0xEA00u) { // 4.6.9 AND (reg), T2 encoding (pg 4-32)
-    u8 const imm2{u8((w1 >> 6u) & 3u)}, imm3{u8((w1 >> 12u) & 7u)},
-      d{u8((w1 >> 8u) & 0xFu)}, s{u8((w0 >> 4u) & 1u)};
-    if ((d == 15) && (s == 1)) { // 4.6.193 TST (reg), T2 encoding (pg 4-399)
+  if ((w0 & 0xFFE0u) == 0xEA00u) {  // 4.6.9 AND (reg), T2 encoding (pg 4-32)
+    u8 const imm2{ u8((w1 >> 6u) & 3u) }, imm3{ u8((w1 >> 12u) & 7u) },
+        d{ u8((w1 >> 8u) & 0xFu) }, s{ u8((w0 >> 4u) & 1u) };
+    if ((d == 15) && (s == 1)) {  // 4.6.193 TST (reg), T2 encoding (pg 4-399)
       out_inst.type = inst_type::TEST_REG;
-      out_inst.i.test_reg = {
-        .shift = decode_imm_shift(u8((w1 >> 4u) & 3u), u8((imm3 << 2u) | imm2)),
-        .n = u8(w0 & 0xFFu), .m = u8(w1 & 0xFFu) };
+      out_inst.i.test_reg = { .shift = decode_imm_shift(u8((w1 >> 4u) & 3u),
+                                                        u8((imm3 << 2u) | imm2)),
+                              .n = u8(w0 & 0xFFu),
+                              .m = u8(w1 & 0xFFu) };
       return true;
     }
     out_inst.type = inst_type::AND_REG;
     out_inst.dr = u16(1u << d);
-    out_inst.i.and_reg = {
-      .shift = decode_imm_shift(u8((w1 >> 4u) & 3u), u8((imm3 << 2u) | imm2)),
-      .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+    out_inst.i.and_reg = { .shift = decode_imm_shift(u8((w1 >> 4u) & 3u),
+                                                     u8((imm3 << 2u) | imm2)),
+                           .n = u8(w0 & 0xFu),
+                           .m = u8(w1 & 0xFu) };
     return true;
   }
 
   // 4.6.10 ASR (imm), T2 encoding (pg 4-34)
   if (((w0 & 0xFFEFu) == 0xEA4Fu) && ((w1 & 0x30u) == 0x20u)) {
-    u8 const imm3{u8((w1 >> 12u) & 7u)}, imm2{u8((w1 >> 6u) & 3u)};
+    u8 const imm3{ u8((w1 >> 12u) & 7u) }, imm2{ u8((w1 >> 6u) & 3u) };
     out_inst.type = inst_type::RSHIFT_ARITH_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 7u));
-    out_inst.i.rshift_arith_imm = {
-      .shift = decode_imm_shift(0b10, u8((imm3 << 2u) | imm2)), .m = u8(w1 & 0xFu) };
+    out_inst.i.rshift_arith_imm = { .shift =
+                                        decode_imm_shift(0b10, u8((imm3 << 2u) | imm2)),
+                                    .m = u8(w1 & 0xFu) };
     return true;
   }
 
   // 4.6.12 B, T3 encoding (pg 4-38)
   if (((w0 & 0xF800u) == 0xF000u) && ((w1 & 0xD000u) == 0x8000u)) {
-    u32 const imm11{w1 & 0x7FFu}, imm6{w0 & 0x3Fu}, j1{(w1 >> 13u) & 1u},
-      j2{(w1 >> 11u) & 1u}, s{(w0 >> 10u) & 1u},
-      imm{sext((s << 20u) | (j2 << 19u) | (j1 << 18u) | (imm6 << 12u) | (imm11 << 1u), 20)},
-      addr{out_inst.addr + 4u + imm};
-    cond_code const cc{cond_code((w0 >> 6u) & 0xFu)};
-    if ((unsigned(cc) & 0xEu) == 0xEu) { // 4.6.88 NOP, T2 encoding (pg 4-189)
-      out_inst.type = inst_type::NOP; out_inst.i.nop = {};
+    u32 const imm11{ w1 & 0x7FFu }, imm6{ w0 & 0x3Fu }, j1{ (w1 >> 13u) & 1u },
+        j2{ (w1 >> 11u) & 1u }, s{ (w0 >> 10u) & 1u },
+        imm{ sext((s << 20u) | (j2 << 19u) | (j1 << 18u) | (imm6 << 12u) | (imm11 << 1u),
+                  20) },
+        addr{ out_inst.addr + 4u + imm };
+    cond_code const cc{ cond_code((w0 >> 6u) & 0xFu) };
+    if ((unsigned(cc) & 0xEu) == 0xEu) {  // 4.6.88 NOP, T2 encoding (pg 4-189)
+      out_inst.type = inst_type::NOP;
+      out_inst.i.nop = {};
       return true;
     }
     out_inst.type = inst_type::BRANCH;
@@ -760,10 +838,12 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.12 B, T4 encoding (pg 4-38)
   if (((w0 & 0xF800u) == 0xF000u) && ((w1 & 0xD000u) == 0x9000u)) {
-    u32 const imm10{w0 & 0x3FFu}, imm11{w1 & 0x7FFu}, s{(w0 >> 10u) & 1u},
-      j1{(w1 >> 13u) & 1u}, j2{(w1 >> 11u) & 1u}, i1{~(j1 ^ s) & 1u}, i2{~(j2 ^ s) & 1u},
-      imm{sext((s << 24u) | (i1 << 23u) | (i2 << 22u) | (imm10 << 12u) | (imm11 << 1u), 24)},
-      addr{out_inst.addr + 4u + imm};
+    u32 const imm10{ w0 & 0x3FFu }, imm11{ w1 & 0x7FFu }, s{ (w0 >> 10u) & 1u },
+        j1{ (w1 >> 13u) & 1u }, j2{ (w1 >> 11u) & 1u }, i1{ ~(j1 ^ s) & 1u },
+        i2{ ~(j2 ^ s) & 1u },
+        imm{ sext((s << 24u) | (i1 << 23u) | (i2 << 22u) | (imm10 << 12u) | (imm11 << 1u),
+                  24) },
+        addr{ out_inst.addr + 4u + imm };
     out_inst.type = inst_type::BRANCH;
     out_inst.i.branch = { .imm = imm, .addr = addr, .cc = cond_code::AL2 };
     return true;
@@ -771,10 +851,10 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.14 BFI, T1 encoding (pg 4-42)
   if (((w0 & 0xFBF0u) == 0xF360u) && ((w1 & 0x8000u) == 0)) {
-    u8 const imm2{u8((w1 >> 6u) & 3u)}, imm3{u8((w1 >> 12u) & 7u)},
-      imm5{u8((imm3 << 2u) | imm2)}, n{u8(w0 & 0xFu)}, msbit{u8(w1 & 0x1Fu)},
-      d{u8((w1 >> 8u) & 0xFu)};
-    if (n == 15) { // 4.6.13 BFC, T1 encoding (pg 4-40)
+    u8 const imm2{ u8((w1 >> 6u) & 3u) }, imm3{ u8((w1 >> 12u) & 7u) },
+        imm5{ u8((imm3 << 2u) | imm2) }, n{ u8(w0 & 0xFu) }, msbit{ u8(w1 & 0x1Fu) },
+        d{ u8((w1 >> 8u) & 0xFu) };
+    if (n == 15) {  // 4.6.13 BFC, T1 encoding (pg 4-40)
       out_inst.type = inst_type::BITFIELD_CLEAR;
       out_inst.i.bitfield_clear = { .d = d, .msbit = msbit, .lsbit = imm5 };
       return true;
@@ -787,28 +867,33 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.15 BIC (imm), T1 encoding (pg 4-44)
   if (((w0 & 0xFBE0u) == 0xF020u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u};
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u };
     out_inst.type = inst_type::BIT_CLEAR_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.bit_clear_imm = { .imm = decode_imm12((i << 11u) | (imm3 << 8u) | imm8),
-      .n = u8(w0 & 0xFu) };
+                                 .n = u8(w0 & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFFE0u) == 0xEA20u) { // 4.6.16 BIC, T2 encoding (pg 4-46)
+  if ((w0 & 0xFFE0u) == 0xEA20u) {  // 4.6.16 BIC, T2 encoding (pg 4-46)
     out_inst.type = inst_type::BIT_CLEAR_REG;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
-    out_inst.i.bit_clear_reg = { .shift = decode_imm_shift(u8((w1 >> 4u) & 3u),
-      u8(((w1 >> 6u) & 3u) | ((w1 >> 12u) & 7u))), .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+    out_inst.i.bit_clear_reg = { .shift = decode_imm_shift(
+                                     u8((w1 >> 4u) & 3u),
+                                     u8(((w1 >> 6u) & 3u) | ((w1 >> 12u) & 7u))),
+                                 .n = u8(w0 & 0xFu),
+                                 .m = u8(w1 & 0xFu) };
     return true;
   }
 
   // 4.6.18 BL, T1 encoding (pg 4-50)
   if (((w0 & 0xF800u) == 0xF000u) && ((w1 & 0xD000u) == 0xD000u)) {
-    u32 const imm10{w0 & 0x3FFu}, imm11{w1 & 0x7FFu}, s{(w0 >> 10u) & 1u},
-      j1{(w1 >> 13u) & 1u}, j2{(w1 >> 11u) & 1u}, i1{~(j1 ^ s) & 1u}, i2{~(j2 ^ s) & 1u};
+    u32 const imm10{ w0 & 0x3FFu }, imm11{ w1 & 0x7FFu }, s{ (w0 >> 10u) & 1u },
+        j1{ (w1 >> 13u) & 1u }, j2{ (w1 >> 11u) & 1u }, i1{ ~(j1 ^ s) & 1u },
+        i2{ ~(j2 ^ s) & 1u };
     u32 const imm32{
-      sext((s << 24u) | (i1 << 23u) | (i2 << 22u) | (imm10 << 12u) | (imm11 << 1u), 24)};
+      sext((s << 24u) | (i1 << 23u) | (i2 << 22u) | (imm10 << 12u) | (imm11 << 1u), 24)
+    };
     out_inst.type = inst_type::BRANCH_LINK;
     out_inst.i.branch_link = { .imm = imm32, .addr = u32(out_inst.addr + 4u + imm32) };
     return true;
@@ -824,10 +909,10 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.36 EOR (imm), T1 encoding (pg 4-86)
   if (((w0 & 0xFBE0u) == 0xF080u) && ((w1 & 0x8000u) == 0)) {
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, s{u8((w0 >> 4u) & 1u)}, n{u8(w0 & 0xFu)};
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u},
-      imm{decode_imm12((i << 11u) | (imm3 << 8u) | imm8)};
-    if ((s == 1) && (d == 15)) { // 4.6.190 TEQ (imm), T1 encoding (pg 4-393)
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, s{ u8((w0 >> 4u) & 1u) }, n{ u8(w0 & 0xFu) };
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u },
+        imm{ decode_imm12((i << 11u) | (imm3 << 8u) | imm8) };
+    if ((s == 1) && (d == 15)) {  // 4.6.190 TEQ (imm), T1 encoding (pg 4-393)
       out_inst.type = inst_type::TEST_EQUIV_IMM;
       out_inst.i.test_equiv_imm = { .imm = imm, .n = n };
       return true;
@@ -838,11 +923,13 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFFE0) == 0xEA80u) { // 4.6.37 EOR (reg), T2 encoding (pg 4-88)
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, s{u8((w0 >> 4u) & 1u)}, imm3{u8((w1 >> 12u) & 7u)},
-      imm2{u8((w1 >> 6u) & 3u)}, m{u8(w1 & 0xFu)}, n{u8(w0 & 0xFu)};
-    imm_shift const shift{decode_imm_shift(u8((w1 >> 4u) & 3u), u8((imm3 << 2u) | imm2))};
-    if ((d == 15) && (s == 1)) { // 4.6.191 TEQ (reg), T1 encoding (pg 4-395)
+  if ((w0 & 0xFFE0) == 0xEA80u) {  // 4.6.37 EOR (reg), T2 encoding (pg 4-88)
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, s{ u8((w0 >> 4u) & 1u) },
+        imm3{ u8((w1 >> 12u) & 7u) }, imm2{ u8((w1 >> 6u) & 3u) }, m{ u8(w1 & 0xFu) },
+        n{ u8(w0 & 0xFu) };
+    imm_shift const shift{ decode_imm_shift(u8((w1 >> 4u) & 3u),
+                                            u8((imm3 << 2u) | imm2)) };
+    if ((d == 15) && (s == 1)) {  // 4.6.191 TEQ (reg), T1 encoding (pg 4-395)
       out_inst.type = inst_type::TEST_EQUIV_REG;
       out_inst.i.test_equiv_reg = { .shift = shift, .n = n, .m = m };
       return true;
@@ -860,21 +947,22 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFFD0u) == 0xE890u) { // 4.6.42 LDMIA, T2 encoding (pg 4-98)
+  if ((w0 & 0xFFD0u) == 0xE890u) {  // 4.6.42 LDMIA, T2 encoding (pg 4-98)
     out_inst.type = inst_type::LOAD_MULT_INC_AFTER;
     out_inst.dr = u16(w1 & 0xDFFFu);
     out_inst.i.load_mult_inc_after = { .n = u8(w0 & 0xFu), .wback = u8((w0 >> 5u) & 1u) };
     return true;
   }
 
-  if ((w0 & 0xFFF0u) == 0xF8D0u) { // 4.6.43 LDR (imm), T3 encoding (pg 4-100)
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, n{u8(w0 & 0xFu)};
-    u16 const imm{u16(w1 & 0xFFFu)};
-    if (n == 15) { // 4.6.44 LDR (literal), T2 encoding (pg 4-102)
+  if ((w0 & 0xFFF0u) == 0xF8D0u) {  // 4.6.43 LDR (imm), T3 encoding (pg 4-100)
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, n{ u8(w0 & 0xFu) };
+    u16 const imm{ u16(w1 & 0xFFFu) };
+    if (n == 15) {  // 4.6.44 LDR (literal), T2 encoding (pg 4-102)
       out_inst.type = inst_type::LOAD_LIT;
       out_inst.dr = u16(1u << t);
       out_inst.i.load_lit = { .imm = imm,
-        .addr = u32(inst_align(out_inst.addr, 4) + imm + 4), .add = u8((w0 >> 7u) & 1u) };
+                              .addr = u32(inst_align(out_inst.addr, 4) + imm + 4),
+                              .add = u8((w0 >> 7u) & 1u) };
       return true;
     }
     out_inst.type = inst_type::LOAD_IMM;
@@ -885,38 +973,44 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.43 LDR (immediate), T4 encoding (pg 4-100)
   if (((w0 & 0xFFF0u) == 0xF850u) && ((w1 & 0x800u) == 0x800u)) {
-    u8 const p{u8((w1 >> 10u) & 1u)}, u{u8((w1 >> 9u) & 1u)}, w{u8((w1 >> 8u) & 1u)};
+    u8 const p{ u8((w1 >> 10u) & 1u) }, u{ u8((w1 >> 9u) & 1u) }, w{ u8((w1 >> 8u) & 1u) };
     if ((p == 1) && (u == 1) && (w == 0)) {
       NL_LOG_ERR("SEE LDRT on page 4-148\n");
       return false;
     }
     out_inst.type = inst_type::LOAD_IMM;
     out_inst.dr = u16(1u << ((w1 >> 12u) & 0xFu));
-    out_inst.i.load_imm = { .imm = u8(w1 & 0xFFu), .n = u8(w0 & 0xFu), .add = u,
-      .index = p };
+    out_inst.i.load_imm = { .imm = u8(w1 & 0xFFu),
+                            .n = u8(w0 & 0xFu),
+                            .add = u,
+                            .index = p };
     return true;
   }
 
   // 4.6.45 LDR (register), T2 encoding (pg 4-104)
   if (((w0 & 0xFFF0u) == 0xF850u) && ((w1 & 0xFC0u) == 0)) {
     out_inst.type = inst_type::LOAD_REG;
-    out_inst.dr = u16(1u << ((w1 >> 12u) & 0xFu)); // t == d
-    out_inst.i.load_reg = { .shift = { .t = imm_shift_type::LSL, .n = u8((w1 >> 4u) & 3u) },
-      .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+    out_inst.dr = u16(1u << ((w1 >> 12u) & 0xFu));  // t == d
+    out_inst.i.load_reg = { .shift = { .t = imm_shift_type::LSL,
+                                       .n = u8((w1 >> 4u) & 3u) },
+                            .n = u8(w0 & 0xFu),
+                            .m = u8(w1 & 0xFu) };
     return true;
   }
 
   if ((w0 & 0xFFF0u) == 0xF890u) {  // 4.6.46 LDRB (imm), T2 encoding (pg 4-106)
     out_inst.type = inst_type::LOAD_BYTE_IMM;
     out_inst.dr = u16(1u << ((w1 >> 12u) & 0xFu));
-    out_inst.i.load_byte_imm = { .imm = u16(w1 & 0xFFFu), .n = u8(w0 & 0xFu), .add = 1u,
-      .index = 1u };
+    out_inst.i.load_byte_imm = { .imm = u16(w1 & 0xFFFu),
+                                 .n = u8(w0 & 0xFu),
+                                 .add = 1u,
+                                 .index = 1u };
     return true;
   }
 
   // 4.6.46 LDRB (imm), T3 encoding (pg 4-106)
   if (((w0 & 0xFFF0u) == 0xF810u) && ((w1 & 0x800u) == 0x800u)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, n{u8(w0 & 0xFu)}, puw{u8((w1 >> 8u) & 3u)};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, n{ u8(w0 & 0xFu) }, puw{ u8((w1 >> 8u) & 3u) };
     if (n == 15) {
       NL_LOG_ERR("SEE LDRB (literal) on page 4-108");
       return false;
@@ -927,19 +1021,21 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     }
     out_inst.type = inst_type::LOAD_BYTE_IMM;
     out_inst.dr = u16(1u << t);
-    out_inst.i.load_byte_imm = { .imm = u16(w1 & 0xFFu), .n = n,
-      .add = u8((puw >> 1u) & 1u), .index = u8((puw >> 2u) & 1u) };
+    out_inst.i.load_byte_imm = { .imm = u16(w1 & 0xFFu),
+                                 .n = n,
+                                 .add = u8((puw >> 1u) & 1u),
+                                 .index = u8((puw >> 2u) & 1u) };
     return true;
   }
 
   // 4.6.48 LDRB (reg), T2 encoding (pg 4-110)
   if (((w0 & 0xFFF0u) == 0xF810u) && ((w1 & 0xFC0u) == 0)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, n{u8(w0 & 0xFu)};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, n{ u8(w0 & 0xFu) };
     if (t == 15) {
       NL_LOG_ERR("SEE PLD (register) on page 4-203");
       return false;
     }
-    if (n == 15) { // 4.6.47 LDRB (lit), T1 encoding (pg 4-108)
+    if (n == 15) {  // 4.6.47 LDRB (lit), T1 encoding (pg 4-108)
       if (t == 15) {
         NL_LOG_ERR("SEE PLD (immediate) on page 4-201");
         return false;
@@ -950,28 +1046,29 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     } else {
       out_inst.type = inst_type::LOAD_BYTE_REG;
       out_inst.dr = u16(1u << t);
-      out_inst.i.load_byte_reg = {
-        .shift = decode_imm_shift(u8(imm_shift_type::LSL), u8((w1 >> 4u) & 3u)), .n = n,
-        .m = u8(w1 & 0xFu) };
+      out_inst.i.load_byte_reg = { .shift = decode_imm_shift(u8(imm_shift_type::LSL),
+                                                             u8((w1 >> 4u) & 3u)),
+                                   .n = n,
+                                   .m = u8(w1 & 0xFu) };
     }
     return true;
   }
 
-  if ((w0 & 0xFE50u) == 0xE850u) { // 4.6.50 LDRD (imm), T1 encoding (pg 4-114)
-    u8 const p{u8((w0 >> 8u) & 1u)}, u{u8((w0 >> 7u) & 1u)}, w{u8((w0 >> 5u) & 1u)};
+  if ((w0 & 0xFE50u) == 0xE850u) {  // 4.6.50 LDRD (imm), T1 encoding (pg 4-114)
+    u8 const p{ u8((w0 >> 8u) & 1u) }, u{ u8((w0 >> 7u) & 1u) }, w{ u8((w0 >> 5u) & 1u) };
     if ((p == 0) && (w == 0)) {
-      if (u == 0) { // 4.6.51 LDREX, T1 encoding (pg 4-116)
+      if (u == 0) {  // 4.6.51 LDREX, T1 encoding (pg 4-116)
         out_inst.type = inst_type::LOAD_EXCL;
         out_inst.dr = u16(1u << ((w1 >> 12u) & 0xFu));
         out_inst.i.load_excl = { .imm = u16((w1 & 0xFFu) << 2u), .n = u8(w0 & 0xFu) };
         return true;
       } else {
-        if ((w1 & 0xF0u) == 0x10) { // 4.6.189 TBH, T1 encoding (pg 4-391)
+        if ((w1 & 0xF0u) == 0x10) {  // 4.6.189 TBH, T1 encoding (pg 4-391)
           out_inst.type = inst_type::TABLE_BRANCH_HALF;
           out_inst.i.table_branch_half = { .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
           return true;
         }
-        if ((w1 & 0xF0u) == 0) { // 4.6.188 TBB, T1 encoding (pg 4-389)
+        if ((w1 & 0xF0u) == 0) {  // 4.6.188 TBB, T1 encoding (pg 4-389)
           out_inst.type = inst_type::TABLE_BRANCH_BYTE;
           out_inst.i.table_branch_byte = { .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
           return true;
@@ -979,26 +1076,32 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
         return false;
       }
     }
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, t2{u8((w1 >> 8u) & 0xFu)};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, t2{ u8((w1 >> 8u) & 0xFu) };
     out_inst.type = inst_type::LOAD_DBL_REG;
     out_inst.dr = u16((1u << t) | (1u << t2));
-    out_inst.i.load_dbl_reg = { .imm = u16((w1 & 0xFFu) << 2u), .t = t, .t2 = t2,
-      .n = u8(w0 & 0xFu), .index = p, .add = u };
+    out_inst.i.load_dbl_reg = { .imm = u16((w1 & 0xFFu) << 2u),
+                                .t = t,
+                                .t2 = t2,
+                                .n = u8(w0 & 0xFu),
+                                .index = p,
+                                .add = u };
     return true;
   }
 
-  if ((w0 & 0xFFF0u) == 0xF8B0u) { // 4.6.55 LDRH (imm), T2 encoding (pg 4-124)
+  if ((w0 & 0xFFF0u) == 0xF8B0u) {  // 4.6.55 LDRH (imm), T2 encoding (pg 4-124)
     out_inst.type = inst_type::LOAD_HALF_IMM;
     out_inst.dr = u16(1u << ((w1 >> 12u) & 0xFu));
-    out_inst.i.load_half_imm = { .imm = u16(w1 & 0xFFFu), .n = u8(w0 & 0xFu), .add = 1u,
-      .index = 1u };
+    out_inst.i.load_half_imm = { .imm = u16(w1 & 0xFFFu),
+                                 .n = u8(w0 & 0xFu),
+                                 .add = 1u,
+                                 .index = 1u };
     return true;
   }
 
   // 4.6.55 LDRH (imm), T3 encoding (pg 4-124)
   if (((w0 & 0xFFF0u) == 0xF830u) && ((w1 & 0x800u) == 0x800u)) {
-    u8 const p{u8((w1 >> 10u) & 1u)}, u{u8((w1 >> 9u) & 1u)}, w{u8((w1 >> 8u) & 1u)},
-      n{u8(w0 & 0xFu)}, t{u8((w1 >> 12u) & 0xFu)};
+    u8 const p{ u8((w1 >> 10u) & 1u) }, u{ u8((w1 >> 9u) & 1u) }, w{ u8((w1 >> 8u) & 1u) },
+        n{ u8(w0 & 0xFu) }, t{ u8((w1 >> 12u) & 0xFu) };
     if (n == 15) {
       printf("SEE LDRH (literal) on page 4-126\n");
       return false;
@@ -1019,8 +1122,9 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.57 LDRH (reg), T2 encoding (pg 4-128)
   if (((w0 & 0xFFF0u) == 0xF830u) && ((w1 & 0xFC0u) == 0)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, m{u8(w1 & 0xFu)}, n{u8(w0 & 0xFu)};
-    imm_shift const shift{decode_imm_shift(u8(imm_shift_type::LSL), u8((w1 >> 4u) & 3u))};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, m{ u8(w1 & 0xFu) }, n{ u8(w0 & 0xFu) };
+    imm_shift const shift{ decode_imm_shift(u8(imm_shift_type::LSL),
+                                            u8((w1 >> 4u) & 3u)) };
     if (n == 15) {
       printf("SEE LDRH (literal) on page 4-126\n");
       return false;
@@ -1035,19 +1139,21 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFFF0u) == 0xF990u) { // 4.6.59 LDRSB (imm), T1 encoding (pg 4-132)
+  if ((w0 & 0xFFF0u) == 0xF990u) {  // 4.6.59 LDRSB (imm), T1 encoding (pg 4-132)
     out_inst.type = inst_type::LOAD_SIGNED_BYTE_IMM;
     out_inst.dr = u16(1u << ((w0 >> 12u) & 0xFu));
-    out_inst.i.load_signed_byte_imm = { .imm = u16(w1 & 0xFFFu), .n = u8(w0 & 0xFu),
-      .index = 1u, .add = 1u };
+    out_inst.i.load_signed_byte_imm = { .imm = u16(w1 & 0xFFFu),
+                                        .n = u8(w0 & 0xFu),
+                                        .index = 1u,
+                                        .add = 1u };
     return true;
   }
 
   // 4.6.59 LDRSB (imm), T2 encoding (pg 4-132)
   if (((w0 & 0xFFF0u) == 0xF910u) && ((w1 & 0x800u) == 0x800u)) {
-    u8 const n{u8(w0 & 0xFu)}, t{u8((w1 >> 12u) & 0xFu)}, p{u8((w1 >> 10u) & 1u)},
-      u{u8((w1 >> 9u) & 1u)}, w{u8((w1 >> 8u) & 1u)};
-    u16 const imm{u16(w1 & 0xFFu)};
+    u8 const n{ u8(w0 & 0xFu) }, t{ u8((w1 >> 12u) & 0xFu) }, p{ u8((w1 >> 10u) & 1u) },
+        u{ u8((w1 >> 9u) & 1u) }, w{ u8((w1 >> 8u) & 1u) };
+    u16 const imm{ u16(w1 & 0xFFu) };
     if (n == 15) {
       NL_LOG_DBG("SEE LDRSB (literal) on page 4-134;\n");
       return false;
@@ -1068,8 +1174,8 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.61 LDRSB (reg), T2 encoding (pg 4-136)
   if (((w0 & 0xFFF0u) == 0xF910u) && ((w1 & 0xFC0u) == 0)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, m{u8(w1 & 0xFu)}, n{u8(w0 & 0xFu)},
-      shift{u8((w1 >> 4u) & 3u)};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, m{ u8(w1 & 0xFu) }, n{ u8(w0 & 0xFu) },
+        shift{ u8((w1 >> 4u) & 3u) };
     if (t == 15) {
       printf("SEE PLI (register) on page 4-207\n");
       return false;
@@ -1080,13 +1186,15 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     }
     out_inst.type = inst_type::LOAD_SIGNED_BYTE_REG;
     out_inst.dr = u16(1u << t);
-    out_inst.i.load_signed_byte_reg = {
-      .shift = decode_imm_shift(u8(imm_shift_type::LSL), shift), .n = n, .m = m };
+    out_inst.i.load_signed_byte_reg = { .shift = decode_imm_shift(u8(imm_shift_type::LSL),
+                                                                  shift),
+                                        .n = n,
+                                        .m = m };
     return true;
   }
 
-  if ((w0 & 0xFFF0u) == 0xF9B0u) { // 4.6.63 LDRSH (imm), T1 encoding (pg 4-140)
-    u8 const n{u8(w0 & 0xFu)}, t{u8((w1 >> 12u) & 0xFu)};
+  if ((w0 & 0xFFF0u) == 0xF9B0u) {  // 4.6.63 LDRSH (imm), T1 encoding (pg 4-140)
+    u8 const n{ u8(w0 & 0xFu) }, t{ u8((w1 >> 12u) & 0xFu) };
     if (n == 15) {
       NL_LOG_ERR("SEE LDRSH (literal) on page 4-142");
       return false;
@@ -1097,16 +1205,18 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     }
     out_inst.type = inst_type::LOAD_SIGNED_HALF_IMM;
     out_inst.dr = u16(1u << t);
-    out_inst.i.load_signed_half_imm = { .imm = u16(w1 & 0xFFFu), .n = n, .index = 1u,
-      .add = 1u };
+    out_inst.i.load_signed_half_imm = { .imm = u16(w1 & 0xFFFu),
+                                        .n = n,
+                                        .index = 1u,
+                                        .add = 1u };
     return true;
   }
 
   // 4.6.63 LDRSH (imm), T2 encoding (pg 4-140)
   if (((w0 & 0xFFF0u) == 0xF930u) && ((w1 & 0x800u) == 0x800u)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, n{u8(w0 & 0xFu)}, p{u8((w0 >> 10u) & 1u)},
-      u{u8((w1 >> 9u) & 1u)}, w{u8((w1 >> 8u) & 1u)};
-    u16 const imm{u16(w1 & 0xFFu)};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, n{ u8(w0 & 0xFu) }, p{ u8((w0 >> 10u) & 1u) },
+        u{ u8((w1 >> 9u) & 1u) }, w{ u8((w1 >> 8u) & 1u) };
+    u16 const imm{ u16(w1 & 0xFFu) };
     if (n == 15) {
       NL_LOG_DBG("SEE LDRSH (literal) on page 4-142\n");
       return false;
@@ -1127,7 +1237,7 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.65 LDRSH (reg), T2 encoding (pg 4-144)
   if (((w0 & 0xFFF0u) == 0xF930u) && ((w1 & 0xFC0u) == 0)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, n{u8(w0 & 0xFu)};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, n{ u8(w0 & 0xFu) };
     if (n == 15) {
       NL_LOG_ERR("SEE LDRSH (literal) on page 4-142");
       return false;
@@ -1138,23 +1248,25 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     }
     out_inst.type = inst_type::LOAD_SIGNED_HALF_REG;
     out_inst.dr = u16(1u << t);
-    out_inst.i.load_signed_half_reg = {
-      .shift = decode_imm_shift(u8(imm_shift_type::LSL), u8((w1 >> 4u) & 3u)), .n = n,
-      .m = u8(w1 & 0xFu) };
+    out_inst.i.load_signed_half_reg = { .shift = decode_imm_shift(u8(imm_shift_type::LSL),
+                                                                  u8((w1 >> 4u) & 3u)),
+                                        .n = n,
+                                        .m = u8(w1 & 0xFu) };
     return true;
   }
 
   // 4.6.68 LSL (imm), T2 encoding (pg 4-150)
   if (((w0 & 0xFFEFu) == 0xEA4Fu) && ((w1 & 0x30u) == 0)) {
-    u8 const imm3{u8((w1 >> 12u) & 7u)}, imm2{u8((w1 >> 6u) & 3u)},
-      imm{u8((imm3 << 2u) | imm2)};
+    u8 const imm3{ u8((w1 >> 12u) & 7u) }, imm2{ u8((w1 >> 6u) & 3u) },
+        imm{ u8((imm3 << 2u) | imm2) };
     if (imm == 0) {
       NL_LOG_DBG("4.6.68 LSL (imm), T2 encoding (pg 4-150)\n");
       return false;
     }
     out_inst.type = inst_type::LSHIFT_LOG_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
-    out_inst.i.lshift_log_imm = { .shift = decode_imm_shift(0b00, imm), .m = u8(w1 & 0xFu) };
+    out_inst.i.lshift_log_imm = { .shift = decode_imm_shift(0b00, imm),
+                                  .m = u8(w1 & 0xFu) };
     return true;
   }
 
@@ -1168,11 +1280,11 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.70 LSR (imm), T2 encoding (pg 4-154)
   if (((w0 & 0xFFEFu) == 0xEA4Fu) && ((w1 & 0x30u) == 0x10u)) {
-    u8 const imm3{u8((w1 >> 12u) & 7u)}, imm2{u8((w1 >> 6u) & 7u)};
+    u8 const imm3{ u8((w1 >> 12u) & 7u) }, imm2{ u8((w1 >> 6u) & 7u) };
     out_inst.type = inst_type::RSHIFT_LOG_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.rshift_log_imm = { .shift = decode_imm_shift(0b01, u8((imm3 << 2u) | imm2)),
-      .m = u8(w1 & 0xFu) };
+                                  .m = u8(w1 & 0xFu) };
     return true;
   }
 
@@ -1188,8 +1300,9 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
   if (((w0 & 0xFFF0u) == 0xFB00u) && ((w1 & 0xF0u) == 0)) {
     out_inst.type = inst_type::MUL_ACCUM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
-    out_inst.i.mul_accum = { .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu),
-      .a = u8((w1 >> 12u) & 0xFu) };
+    out_inst.i.mul_accum = { .n = u8(w0 & 0xFu),
+                             .m = u8(w1 & 0xFu),
+                             .a = u8((w1 >> 12u) & 0xFu) };
     return true;
   }
 
@@ -1197,14 +1310,15 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
   if (((w0 & 0xFFF0u) == 0xFB00u) && ((w1 & 0xF0u) == 0x10u)) {
     out_inst.type = inst_type::MUL_SUB;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
-    out_inst.i.mul_sub = { .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu),
-      .a = u8((w1 >> 12u) & 0xFu) };
+    out_inst.i.mul_sub = { .n = u8(w0 & 0xFu),
+                           .m = u8(w1 & 0xFu),
+                           .a = u8((w1 >> 12u) & 0xFu) };
     return true;
   }
 
   // 4.6.76 MOV (imm), T2 encoding (pg 4-166)
   if (((w0 & 0xFBEFu) == 0xF04Fu) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u};
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u };
     out_inst.type = inst_type::MOV_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.mov_imm = { .imm = decode_imm12((i << 11u) | (imm3 << 8u) | imm8) };
@@ -1213,7 +1327,8 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.76 MOV (imm), T3 encoding (pg 4-166)
   if (((w0 & 0xFBF0u) == 0xF240u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u}, imm4{w0 & 0xFu};
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u },
+        imm4{ w0 & 0xFu };
     out_inst.type = inst_type::MOV_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.mov_imm = { .imm = (imm4 << 12u) | (i << 11u) | (imm3 << 8u) | imm8 };
@@ -1222,7 +1337,7 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.85 MVN (imm), T2 encoding (pg 4-183)
   if (((w0 & 0xFBEFu) == 0xF06Fu) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u};
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u };
     out_inst.type = inst_type::MOV_NEG_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.mov_neg_imm = { .imm = decode_imm12((i << 11u) | (imm3 << 8u) | imm8) };
@@ -1232,15 +1347,17 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
   // 4.6.88 NOP, T2 encoding (pg 4-189)
   if (((w0 & 0xFFF0u) == 0xF3A0u) && ((w1 & 0xD7FFu) == 0x8000u)) {
     // don't need nop flag memory hints for static analysis (e.g. dsb, isb)
-    out_inst.type = inst_type::NOP; out_inst.i.nop = {};
+    out_inst.type = inst_type::NOP;
+    out_inst.i.nop = {};
     return true;
   }
 
-  if ((w0 & 0xFFE0u) == 0xEA60u) { // 4.6.90 ORN, T1 encoding (pg 4-193)
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, m{u8(w1 & 0xFu)}, n{u8(w0 & 0xFu)},
-      imm2{u8((w1 >> 6u) & 3u)}, imm3{u8((w1 >> 12u) & 7u)};
-    imm_shift const shift{decode_imm_shift(u8((w1 >> 4u) & 3u), u8((imm3 << 2u) | imm2))};
-    if (n == 15) { // 4.6.86 MVN (reg), T2 encoding (pg 4-185)
+  if ((w0 & 0xFFE0u) == 0xEA60u) {  // 4.6.90 ORN, T1 encoding (pg 4-193)
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, m{ u8(w1 & 0xFu) }, n{ u8(w0 & 0xFu) },
+        imm2{ u8((w1 >> 6u) & 3u) }, imm3{ u8((w1 >> 12u) & 7u) };
+    imm_shift const shift{ decode_imm_shift(u8((w1 >> 4u) & 3u),
+                                            u8((imm3 << 2u) | imm2)) };
+    if (n == 15) {  // 4.6.86 MVN (reg), T2 encoding (pg 4-185)
       out_inst.type = inst_type::MOV_NEG_REG;
       out_inst.dr = u16(1u << d);
       out_inst.i.mov_neg_reg = { .shift = shift, .m = m };
@@ -1254,10 +1371,10 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.91 ORR (imm), T1 encoding (pg 4-195)
   if (((w0 & 0xFB40u) == 0xF040u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u},
-      imm{decode_imm12((i << 11u) | (imm3 << 8u) | imm8)};
-    u8 const n{u8(w0 & 0xFu)}, d{u8((w1 >> 8u) & 0xFu)};
-    if (n == 15) { // 4.6.76 MOV (imm), T2 encoding (pg 4-166)
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u },
+        imm{ decode_imm12((i << 11u) | (imm3 << 8u) | imm8) };
+    u8 const n{ u8(w0 & 0xFu) }, d{ u8((w1 >> 8u) & 0xFu) };
+    if (n == 15) {  // 4.6.76 MOV (imm), T2 encoding (pg 4-166)
       out_inst.type = inst_type::MOV_IMM;
       out_inst.dr = u16(1u << d);
       out_inst.i.mov_imm = { .imm = imm };
@@ -1269,10 +1386,11 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFFE0u) == 0xEA40u) { // 4.6.91 ORR (reg), T2 encoding (pg 4-197)
-    u8 const imm3{u8((w1 >> 12u) & 7u)}, imm2{u8((w1 >> 6u) & 3u)},
-       n{u8(w0 & 0xFu)}, m{u8(w1 & 0xFu)}, d{u8((w1 >> 8u) & 0xFu)};
-    imm_shift const shift{decode_imm_shift(u8((w1 >> 4u) & 3u), u8((imm3 << 2u) | imm2))};
+  if ((w0 & 0xFFE0u) == 0xEA40u) {  // 4.6.91 ORR (reg), T2 encoding (pg 4-197)
+    u8 const imm3{ u8((w1 >> 12u) & 7u) }, imm2{ u8((w1 >> 6u) & 3u) }, n{ u8(w0 & 0xFu) },
+        m{ u8(w1 & 0xFu) }, d{ u8((w1 >> 8u) & 0xFu) };
+    imm_shift const shift{ decode_imm_shift(u8((w1 >> 4u) & 3u),
+                                            u8((imm3 << 2u) | imm2)) };
     if (n == 15) {
       out_inst.type = inst_type::MOV_REG;
       out_inst.dr = u16(1u << d);
@@ -1287,16 +1405,19 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.93 PKH, T1 encoding (pg 4-199)
   if (((w0 & 0xFFF0u) == 0xEAC0u) && ((w1 & 0x10u) == 0)) {
-    u8 const imm2{u8((w1 >> 6u) & 3u)}, imm3{u8((w1 >> 12u) & 7u)}, tb{u8((w1 >> 5u) & 1u)};
+    u8 const imm2{ u8((w1 >> 6u) & 3u) }, imm3{ u8((w1 >> 12u) & 7u) },
+        tb{ u8((w1 >> 5u) & 1u) };
     out_inst.type = inst_type::PACK_HALF;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
-    out_inst.i.pack_half = {
-      .shift = decode_imm_shift(u8(tb << 1u), u8((imm3 << 2u) | imm2)), .n = u8(w0 & 0xFu),
-      .m = u8(w1 & 0xFu), .tbform = tb };
+    out_inst.i.pack_half = { .shift =
+                                 decode_imm_shift(u8(tb << 1u), u8((imm3 << 2u) | imm2)),
+                             .n = u8(w0 & 0xFu),
+                             .m = u8(w1 & 0xFu),
+                             .tbform = tb };
     return true;
   }
 
-  if (w0 == 0xE8BDu) { // 4.6.98 POP, T2 encoding (pg 4-209)
+  if (w0 == 0xE8BDu) {  // 4.6.98 POP, T2 encoding (pg 4-209)
     out_inst.dr = uint16_t(w1 & 0xDFFFu);
     out_inst.type = inst_type::POP;
     return true;
@@ -1312,41 +1433,43 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.118 RSB (imm), T2 encoding (pg 4-249)
   if (((w0 & 0xFBE0u) == 0xF1C0u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u};
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u };
     out_inst.type = inst_type::SUB_REV_IMM;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.sub_rev_imm = { .imm = decode_imm12((i << 11u) | (imm3 << 8u) | imm8),
-      .n = u8(w0 & 0xFu) };
+                               .n = u8(w0 & 0xFu) };
     return true;
   }
 
   if ((w0 & 0xFFE0u) == 0xEBC0u) {
-    u8 const imm2{u8((w1 >> 6u) & 3u)}, imm3{u8((w1 >> 12u) & 7u)},
-      imm{u8((imm3 << 2u) | imm2)};
+    u8 const imm2{ u8((w1 >> 6u) & 3u) }, imm3{ u8((w1 >> 12u) & 7u) },
+        imm{ u8((imm3 << 2u) | imm2) };
     out_inst.type = inst_type::SUB_REV_REG;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.sub_rev_reg = { .shift = decode_imm_shift(u8((w1 >> 4u) & 3u), imm),
-      .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+                               .n = u8(w0 & 0xFu),
+                               .m = u8(w1 & 0xFu) };
     return true;
   }
 
   // 4.6.123 SBC (imm), T1 encoding (pg 4-259)
   if (((w0 & 0xFBE0u) == 0xF160u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u};
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u };
     out_inst.type = inst_type::SUB_IMM_CARRY;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.sub_imm_carry = { .imm = decode_imm12((i << 11u) | (imm3 << 8u) | imm8),
-      .n = u8(w0 & 0xFu) };
+                                 .n = u8(w0 & 0xFu) };
     return true;
   }
 
   // 4.6.125 SBFX, T1 encoding (pg 4-263)
   if (((w0 & 0xFBF0u) == 0xF340u) && ((w1 & 0x8000u) == 0)) {
-    u8 const imm2{u8((w1 >> 6u) & 3u)}, imm3{u8((w1 >> 12u) & 7u)};
+    u8 const imm2{ u8((w1 >> 6u) & 3u) }, imm3{ u8((w1 >> 12u) & 7u) };
     out_inst.type = inst_type::BITFIELD_EXTRACT_SIGNED;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.bitfield_extract_signed = { .n = u8(w0 & 0xFu),
-      .lsbit = u8((imm3 << 2u) | imm2), .widthminus1 = u8(w1 & 0x1Fu) };
+                                           .lsbit = u8((imm3 << 2u) | imm2),
+                                           .widthminus1 = u8(w1 & 0x1Fu) };
     return true;
   }
 
@@ -1358,13 +1481,14 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFFE0u) == 0xEB60) { // 4.6.124 SBC (reg), T2 encoding (pg 4-261)
-    u32 const imm2{(w1 >> 6u) & 3u}, imm3{(w1 >> 12u) & 7u};
+  if ((w0 & 0xFFE0u) == 0xEB60) {  // 4.6.124 SBC (reg), T2 encoding (pg 4-261)
+    u32 const imm2{ (w1 >> 6u) & 3u }, imm3{ (w1 >> 12u) & 7u };
     out_inst.type = inst_type::SUB_REG_CARRY;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
-    out_inst.i.sub_reg_carry = {
-      .shift = decode_imm_shift(u8((w1 >> 4u) & 3u), u8((imm3 << 2u) | imm2)),
-      .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+    out_inst.i.sub_reg_carry = { .shift = decode_imm_shift(u8((w1 >> 4u) & 3u),
+                                                           u8((imm3 << 2u) | imm2)),
+                                 .n = u8(w0 & 0xFu),
+                                 .m = u8(w1 & 0xFu) };
     return true;
   }
 
@@ -1378,8 +1502,8 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.137 SMLABB, SMLABT, SMLATB, SMLATT, T1 encoding (pg 4-287)
   if (((w0 & 0xFFF0u) == 0xFB10u) && ((w1 & 0xC0u) == 0)) {
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, m{u8(w1 & 0xFu)}, n{u8(w0 & 0xFu)},
-      a{u8((w1 >> 12u) & 0xFu)}, M{u8((w1 >> 4u) & 1u)}, N{u8((w1 >> 5u) & 1u)};
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, m{ u8(w1 & 0xFu) }, n{ u8(w0 & 0xFu) },
+        a{ u8((w1 >> 12u) & 0xFu) }, M{ u8((w1 >> 4u) & 1u) }, N{ u8((w1 >> 5u) & 1u) };
     if (a == 15) {
       // 4.6.149 SMULBB, SMULBT, SMULTB, SMULTT, T1 encoding (pg 4-311)
       out_inst.type = inst_type::MUL_SIGNED_HALF;
@@ -1389,17 +1513,23 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     }
     out_inst.type = inst_type::MUL_ACCUM_SIGNED_HALF;
     out_inst.dr = u16(1u << d);
-    out_inst.i.mul_accum_signed_half = { .n = n, .m = m, .a = a, .n_high = N, .m_high = M };
+    out_inst.i.mul_accum_signed_half = { .n = n,
+                                         .m = m,
+                                         .a = a,
+                                         .n_high = N,
+                                         .m_high = M };
     return true;
   }
 
   // 4.6.139 SMLAL, T1 encoding (pg 4-291)
   if (((w0 & 0xFFF0u) == 0xFBC0u) && ((w1 & 0xF0u) == 0)) {
-    u8 const dlo{u8((w1 >> 12u) & 0xFu)}, dhi{u8((w1 >> 8u) & 0xFu)};
+    u8 const dlo{ u8((w1 >> 12u) & 0xFu) }, dhi{ u8((w1 >> 8u) & 0xFu) };
     out_inst.dr = u16((1u << dlo) | (1u << dhi));
     out_inst.type = inst_type::MUL_ACCUM_SIGNED_LONG;
-    out_inst.i.mul_accum_signed_long = { .dlo = dlo, .dhi = dhi, .n = u8(w0 & 0xFu),
-      .m = u8(w1 & 0xFu) };
+    out_inst.i.mul_accum_signed_long = { .dlo = dlo,
+                                         .dhi = dhi,
+                                         .n = u8(w0 & 0xFu),
+                                         .m = u8(w1 & 0xFu) };
     return true;
   }
 
@@ -1407,34 +1537,38 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
   if (((w0 & 0xFFF0u) == 0xFB80u) && ((w1 & 0xF0u) == 0)) {
     out_inst.type = inst_type::MUL_SIGNED_LONG;
     out_inst.i.mul_signed_long = { .dlo = u8((w1 >> 12u) & 0xFu),
-      .dhi = u8((w1 >> 8u) & 0xFu), .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+                                   .dhi = u8((w1 >> 8u) & 0xFu),
+                                   .n = u8(w0 & 0xFu),
+                                   .m = u8(w1 & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFFD0u) == 0xE900u) { // 4.6.160 STMDB, T1 encoding (pg 4-333)
+  if ((w0 & 0xFFD0u) == 0xE900u) {  // 4.6.160 STMDB, T1 encoding (pg 4-333)
     out_inst.type = inst_type::STORE_MULT_DEC_BEFORE;
     out_inst.i.store_mult_dec_before = { .regs = u16(w1 & 0x5FFFu), .n = u8(w0 & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFFD0u) == 0xE880u) { // 4.6.161 STMIA, T2 encoding (pg 4-335)
+  if ((w0 & 0xFFD0u) == 0xE880u) {  // 4.6.161 STMIA, T2 encoding (pg 4-335)
     out_inst.type = inst_type::STORE_MULT_INC_AFTER;
-    out_inst.i.store_mult_inc_after = { .regs = u16(w1 & 0x5FFFu), .n = u8(w0 & 0xFu),
-      .wback = u8((w0 >> 5u) & 1u) };
+    out_inst.i.store_mult_inc_after = { .regs = u16(w1 & 0x5FFFu),
+                                        .n = u8(w0 & 0xFu),
+                                        .wback = u8((w0 >> 5u) & 1u) };
     return true;
   }
 
-  if ((w0 & 0xFFF0u) == 0xF8C0u) { // 4.6.162 STR (imm), T3 encoding (pg 4-337)
+  if ((w0 & 0xFFF0u) == 0xF8C0u) {  // 4.6.162 STR (imm), T3 encoding (pg 4-337)
     out_inst.type = inst_type::STORE_IMM;
-    out_inst.i.store_imm = { .imm = u16(w1 & 0xFFFu), .t = u8(w1 >> 12u),
-      .n = u8(w0 & 0xFu) };
+    out_inst.i.store_imm = { .imm = u16(w1 & 0xFFFu),
+                             .t = u8(w1 >> 12u),
+                             .n = u8(w0 & 0xFu) };
     return true;
   }
 
   // 4.6.162 STR (imm), T4 encoding (pg 4-337)
   if (((w0 & 0xFFF0u) == 0xF840) && ((w1 & 0x800u) == 0x800u)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, n{u8(w0 & 0xFu)}, imm8{u8(w1 & 0xFFu)},
-      p{u8((w1 >> 10u) & 1u)}, u{u8((w1 >> 9u) & 1u)}, w{u8((w1 >> 8u) & 1u)};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, n{ u8(w0 & 0xFu) }, imm8{ u8(w1 & 0xFFu) },
+        p{ u8((w1 >> 10u) & 1u) }, u{ u8((w1 >> 9u) & 1u) }, w{ u8((w1 >> 8u) & 1u) };
     if ((p == 1) && (u == 1) && (w == 0)) {
       NL_LOG_ERR("SEE STRT on page 4-363");
       return false;
@@ -1447,64 +1581,80 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
   // 4.6.163 STR (reg), T2 encoding (pg 4-339)
   if (((w0 & 0xFFF0u) == 0xF840u) && ((w1 & 0xFC0u) == 0)) {
     out_inst.type = inst_type::STORE_REG;
-    out_inst.i.store_reg = {
-      .shift = decode_imm_shift(u8(imm_shift_type::LSL), u8((w1 >> 4u) & 3u)),
-      .t = u8((w1 >> 12u) & 0xFu), .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+    out_inst.i.store_reg = { .shift = decode_imm_shift(u8(imm_shift_type::LSL),
+                                                       u8((w1 >> 4u) & 3u)),
+                             .t = u8((w1 >> 12u) & 0xFu),
+                             .n = u8(w0 & 0xFu),
+                             .m = u8(w1 & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFFF0u) == 0xF880u) { // 4.6.164 STRB (imm), T2 encoding (pg 4-341)
+  if ((w0 & 0xFFF0u) == 0xF880u) {  // 4.6.164 STRB (imm), T2 encoding (pg 4-341)
     out_inst.type = inst_type::STORE_BYTE_IMM;
-    out_inst.i.store_byte_imm = { .imm = u16(w1 & 0xFFFu), .n = u8(w0 & 0xFu),
-      .t = u8((w1 >> 12u) & 0xFu), .index = 1u, .add = 1u };
+    out_inst.i.store_byte_imm = { .imm = u16(w1 & 0xFFFu),
+                                  .n = u8(w0 & 0xFu),
+                                  .t = u8((w1 >> 12u) & 0xFu),
+                                  .index = 1u,
+                                  .add = 1u };
     return true;
   }
 
   // 4.6.164 STRB (imm), T3 encoding (pg 4-341)
   if (((w0 & 0xFFF0u) == 0xF800u) && ((w1 & 0x800u) == 0x800u)) {
-    u8 const p{u8((w1 >> 10u) & 1u)}, u{u8((w1 >> 9u) & 1u)}, w{u8((w1 >> 8u) & 1u)},
-      imm8{u8(w1 & 0xFFu)};
-    if ((p == 1) && (u == 1) && (w == 0)) { // 4.6.166 STRBT, T1 encoding (pg 4-345)
+    u8 const p{ u8((w1 >> 10u) & 1u) }, u{ u8((w1 >> 9u) & 1u) }, w{ u8((w1 >> 8u) & 1u) },
+        imm8{ u8(w1 & 0xFFu) };
+    if ((p == 1) && (u == 1) && (w == 0)) {  // 4.6.166 STRBT, T1 encoding (pg 4-345)
       out_inst.type = inst_type::STORE_BYTE_UNPRIV;
-      out_inst.i.store_byte_unpriv = { .imm = u16(imm8), .t = u8((w1 >> 12u) & 0xFu),
-        .n = u8(w0 & 0xFu) };
+      out_inst.i.store_byte_unpriv = { .imm = u16(imm8),
+                                       .t = u8((w1 >> 12u) & 0xFu),
+                                       .n = u8(w0 & 0xFu) };
       return true;
     }
     out_inst.type = inst_type::STORE_BYTE_IMM;
-    out_inst.i.store_byte_imm = { .imm = u16(imm8), .n = u8(w0 & 0xFu),
-      .t = u8((w1 >> 12u) & 0xFu), .index = p, .add = u };
+    out_inst.i.store_byte_imm = { .imm = u16(imm8),
+                                  .n = u8(w0 & 0xFu),
+                                  .t = u8((w1 >> 12u) & 0xFu),
+                                  .index = p,
+                                  .add = u };
     return true;
   }
 
   // 4.6.165 STRB (reg), T2 encoding (pg 4-343)
   if (((w0 & 0xFFF0u) == 0xF800u) && ((w1 & 0xFC0u) == 0)) {
     out_inst.type = inst_type::STORE_BYTE_REG;
-    out_inst.i.store_byte_reg = {
-      .shift = decode_imm_shift(u8(imm_shift_type::LSL), u8((w1 >> 4u) & 3u)),
-      .t = u8((w1 >> 12u) & 0xFu), .m = u8(w1 & 0xFu), .n = u8(w0 & 0xFu) };
+    out_inst.i.store_byte_reg = { .shift = decode_imm_shift(u8(imm_shift_type::LSL),
+                                                            u8((w1 >> 4u) & 3u)),
+                                  .t = u8((w1 >> 12u) & 0xFu),
+                                  .m = u8(w1 & 0xFu),
+                                  .n = u8(w0 & 0xFu) };
     return true;
   }
 
-  if ((w0 & 0xFE50u) == 0xE840u) { // 4.6.167 STRD (imm), T1 encoding (pg 4-347)
-    u8 const p{u8((w0 >> 8u) & 1u)}, w{u8((w0 >> 5u) & 1u)};
+  if ((w0 & 0xFE50u) == 0xE840u) {  // 4.6.167 STRD (imm), T1 encoding (pg 4-347)
+    u8 const p{ u8((w0 >> 8u) & 1u) }, w{ u8((w0 >> 5u) & 1u) };
     if ((p == 0) && (w == 0)) {  // 4.6.168 STREX, T1 encoding (pg 4-349)
       out_inst.type = inst_type::STORE_EXCL;
-      out_inst.i.store_excl = { .imm = u16((w1 & 0xFFu) << 2u), .d = u8((w1 >> 8u) & 0xFu),
-        .t = u8((w1 >> 12u) & 0xFu), .n = u8(w0 & 0xFu) };
+      out_inst.i.store_excl = { .imm = u16((w1 & 0xFFu) << 2u),
+                                .d = u8((w1 >> 8u) & 0xFu),
+                                .t = u8((w1 >> 12u) & 0xFu),
+                                .n = u8(w0 & 0xFu) };
       return true;
     }
     out_inst.type = inst_type::STORE_DOUBLE_IMM;
     out_inst.i.store_double_imm = { .imm = u16((w1 & 0xFFu) << 2u),
-      .t = u8((w1 >> 12u) & 0xFu), .t2 = u8((w1 >> 8u) & 0xFu),
-      .n = u8(w0 & 0xFu), .add = u8((w0 >> 7u) & 1u), .index = p };
+                                    .t = u8((w1 >> 12u) & 0xFu),
+                                    .t2 = u8((w1 >> 8u) & 0xFu),
+                                    .n = u8(w0 & 0xFu),
+                                    .add = u8((w0 >> 7u) & 1u),
+                                    .index = p };
     return true;
   }
 
-  if ((w0 & 0xFFE0u) == 0xEBA0u) { // 4.6.177 SUB (reg), T2 encoding (pg 4-367)
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, n{u8(w0 & 0xFu)}, s{u8((w0 >> 4u) & 1u)},
-      m{u8(w1 & 0xFu)}, imm2{u8((w1 >> 6u) & 3u)}, imm3{u8((w1 >> 12u) & 7u)};
-    imm_shift const shift{decode_imm_shift(u8((w1 >> 4u) & 3u), u8(imm3 << 2u) | imm2)};
-    if ((d == 15) && (s == 1)) { // 4.6.30 CMP (reg), T3 encoding (pg 4-74)
+  if ((w0 & 0xFFE0u) == 0xEBA0u) {  // 4.6.177 SUB (reg), T2 encoding (pg 4-367)
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, n{ u8(w0 & 0xFu) }, s{ u8((w0 >> 4u) & 1u) },
+        m{ u8(w1 & 0xFu) }, imm2{ u8((w1 >> 6u) & 3u) }, imm3{ u8((w1 >> 12u) & 7u) };
+    imm_shift const shift{ decode_imm_shift(u8((w1 >> 4u) & 3u), u8(imm3 << 2u) | imm2) };
+    if ((d == 15) && (s == 1)) {  // 4.6.30 CMP (reg), T3 encoding (pg 4-74)
       out_inst.type = inst_type::CMP_REG;
       out_inst.i.cmp_reg = { .shift = shift, .n = n, .m = m };
       return true;
@@ -1519,17 +1669,20 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
     return true;
   }
 
-  if ((w0 & 0xFFF0u) == 0xF8A0u) { // 4.6.172 STRH (imm), T2 encoding (pg 4-357)
+  if ((w0 & 0xFFF0u) == 0xF8A0u) {  // 4.6.172 STRH (imm), T2 encoding (pg 4-357)
     out_inst.type = inst_type::STORE_HALF_IMM;
-    out_inst.i.store_half_imm = { .imm = u16(w1 & 0xFFFu), .t = u8((w1 >> 12u) & 0xFu),
-      .n = u8(w0 & 0xFu), .index = 1u, .add = 1u };
+    out_inst.i.store_half_imm = { .imm = u16(w1 & 0xFFFu),
+                                  .t = u8((w1 >> 12u) & 0xFu),
+                                  .n = u8(w0 & 0xFu),
+                                  .index = 1u,
+                                  .add = 1u };
     return true;
   }
 
   // 4.6.172 STRH (imm), T3 encoding (pg 4-357)
   if (((w0 & 0xFFF0u) == 0xF820u) && ((w1 & 0x800u) == 0x800u)) {
-    u8 const n{u8(w0 & 0xFu)}, t{u8((w1 >> 12u) & 0xFu)}, imm{u8(w1 & 0xFu)},
-      p{u8((w1 >> 10u) & 1u)}, u{u8((w1 >> 9u) & 1u)}, w{u8((w1 >> 8u) & 1u)};
+    u8 const n{ u8(w0 & 0xFu) }, t{ u8((w1 >> 12u) & 0xFu) }, imm{ u8(w1 & 0xFu) },
+        p{ u8((w1 >> 10u) & 1u) }, u{ u8((w1 >> 9u) & 1u) }, w{ u8((w1 >> 8u) & 1u) };
     if ((p == 1) && (u == 1) && (w == 0)) {
       NL_LOG_DBG("SEE STRHT on page 4-361\n");
       return false;
@@ -1542,46 +1695,48 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
   // 4.6.173 STRH (reg), T2 encoding (pg 4-359)
   if (((w0 & 0xFFF0u) == 0xF820u) && ((w1 & 0xFC0u) == 0)) {
     out_inst.type = inst_type::STORE_HALF_REG;
-    out_inst.i.store_half_reg = {
-      .shift = decode_imm_shift(u8(imm_shift_type::LSL), u8((w1 >> 4u) & 3u)),
-      .t = u8((w1 >> 12u) & 0xFu), .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+    out_inst.i.store_half_reg = { .shift = decode_imm_shift(u8(imm_shift_type::LSL),
+                                                            u8((w1 >> 4u) & 3u)),
+                                  .t = u8((w1 >> 12u) & 0xFu),
+                                  .n = u8(w0 & 0xFu),
+                                  .m = u8(w1 & 0xFu) };
     return true;
   }
 
   // 4.6.176 SUB (imm), T3 encoding (pg 4-365)
   if (((w0 & 0xFBE0u) == 0xF1A0u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm8{w1 & 0xFFu}, imm3{(w1 >> 12u) & 7u}, i{(w0 >> 10u) & 1u},
-      imm{decode_imm12((i << 11u) | (imm3 << 8u) | imm8)};
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, n{u8(w0 & 0xFu)}, s{u8((w0 >> 4u) & 1u)};
-    if ((d == 15) && (s == 1)) { // 4.6.29 CMP (imm), T2 encoding (pg 4-72)
+    u32 const imm8{ w1 & 0xFFu }, imm3{ (w1 >> 12u) & 7u }, i{ (w0 >> 10u) & 1u },
+        imm{ decode_imm12((i << 11u) | (imm3 << 8u) | imm8) };
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, n{ u8(w0 & 0xFu) }, s{ u8((w0 >> 4u) & 1u) };
+    if ((d == 15) && (s == 1)) {  // 4.6.29 CMP (imm), T2 encoding (pg 4-72)
       out_inst.type = inst_type::CMP_IMM;
       out_inst.i.cmp_imm = { .imm = imm, .n = n };
       return true;
     }
-    if (n == 13) { // 4.6.178 SUB (SP minus imm), T2 encoding (pg 4-369)
+    if (n == 13) {  // 4.6.178 SUB (SP minus imm), T2 encoding (pg 4-369)
       out_inst.type = inst_type::SUB_SP_IMM;
       out_inst.dr = u16(1u << d);
       out_inst.i.sub_sp_imm = { .imm = imm };
       return true;
     }
     out_inst.type = inst_type::SUB_IMM;
-      out_inst.dr = u16(1u << d);
+    out_inst.dr = u16(1u << d);
     out_inst.i.sub_imm = { .imm = imm, .n = n };
     return true;
   }
 
   // 4.6.176 SUB (imm), T4 encoding (pg 4-365)
   if (((w0 & 0xFBF0u) == 0xF2A0u) && ((w1 & 0x8000u) == 0)) {
-    u8 const n{u8(w0 & 0xFu)}, d{u8((w1 >> 8u) & 0xFu)};
-    u16 const imm3{u8((w1 >> 12u) & 7u)}, imm8{u8(w1 & 0xFFu)}, i{u8((w0 >> 10u) & 1u)},
-      imm{u16((i << 11u) | (imm3 << 8u) | imm8)};
+    u8 const n{ u8(w0 & 0xFu) }, d{ u8((w1 >> 8u) & 0xFu) };
+    u16 const imm3{ u8((w1 >> 12u) & 7u) }, imm8{ u8(w1 & 0xFFu) },
+        i{ u8((w0 >> 10u) & 1u) }, imm{ u16((i << 11u) | (imm3 << 8u) | imm8) };
     if (n == 15) {
       NL_LOG_ERR("SEE ADR on page 4-28");
       return false;
     }
-    if (n == 13) { // 4.6.178 SUB (SP minus imm), T3 encoding, (pg 4-369)
+    if (n == 13) {  // 4.6.178 SUB (SP minus imm), T3 encoding, (pg 4-369)
       out_inst.type = inst_type::SUB_SP_IMM;
-    out_inst.dr = u16(1u << d);
+      out_inst.dr = u16(1u << d);
       out_inst.i.sub_sp_imm = { .imm = imm };
       return true;
     }
@@ -1593,9 +1748,9 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.182 SXTAB, T1 encoding (pg 4-377)
   if (((w0 & 0xFFF0u) == 0xFA40u) && ((w1 & 0xF080u) == 0xF080u)) {
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, m{u8(w1 & 0xFu)}, n{u8(w0 & 0xFu)},
-      rotation{u8(((w1 >> 4u) & 3u) << 3u)};
-    if (n == 15) { // 4.6.185 SXTB, T2 encoding (pg 4-383)
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, m{ u8(w1 & 0xFu) }, n{ u8(w0 & 0xFu) },
+        rotation{ u8(((w1 >> 4u) & 3u) << 3u) };
+    if (n == 15) {  // 4.6.185 SXTB, T2 encoding (pg 4-383)
       out_inst.type = inst_type::EXTEND_SIGNED_BYTE;
       out_inst.dr = u16(1u << d);
       out_inst.i.extend_signed_byte = { .m = m, .rotation = rotation };
@@ -1609,9 +1764,9 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.184 SXTAH, T1 encoding (pg 4-381)
   if (((w0 & 0xFFF0u) == 0xFA00u) && ((w1 & 0xF080u) == 0xF080u)) {
-    u8 const n{u8(w0 & 0xFu)}, m{u8(w1 & 0xFu)}, d{u8((w1 >> 8u) & 0xFu)},
-      rotation{u8(((w1 >> 4u) & 3u) << 3u)};
-    if (n == 15) { // 4.6.187 SXTH, T2 encoding (pg 4-387)
+    u8 const n{ u8(w0 & 0xFu) }, m{ u8(w1 & 0xFu) }, d{ u8((w1 >> 8u) & 0xFu) },
+        rotation{ u8(((w1 >> 4u) & 3u) << 3u) };
+    if (n == 15) {  // 4.6.187 SXTH, T2 encoding (pg 4-387)
       out_inst.type = inst_type::EXTEND_SIGNED_HALF;
       out_inst.dr = u16(1u << d);
       out_inst.i.extend_signed_half = { .m = m, .rotation = rotation };
@@ -1633,11 +1788,12 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.197 UBFX, T1 encoding (pg 4-407)
   if (((w0 & 0xFBF0u) == 0xF3C0u) && ((w1 & 0x8000u) == 0)) {
-    u32 const imm2{(w1 >> 6u) & 3u}, imm3{(w1 >> 12u) & 7u };
+    u32 const imm2{ (w1 >> 6u) & 3u }, imm3{ (w1 >> 12u) & 7u };
     out_inst.type = inst_type::BITFIELD_EXTRACT_UNSIGNED;
     out_inst.dr = u16(1u << ((w1 >> 8u) & 0xFu));
     out_inst.i.bitfield_extract_unsigned = { .n = u8(w0 & 0xFu),
-      .lsbit = u8((imm3 << 2u) | imm2), .widthminus1 = u8(w1 & 0x1Fu) };
+                                             .lsbit = u8((imm3 << 2u) | imm2),
+                                             .widthminus1 = u8(w1 & 0x1Fu) };
     return true;
   }
 
@@ -1651,11 +1807,13 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.206 UMLAL, T1 encoding (pg 4-425)
   if (((w0 & 0xFFF0u) == 0xFBE0u) && ((w1 & 0xF0u) == 0)) {
-    u8 const dlo{u8((w1 >> 12u) & 0xFu)}, dhi{u8((w1 >> 8u) & 0xFu)};
+    u8 const dlo{ u8((w1 >> 12u) & 0xFu) }, dhi{ u8((w1 >> 8u) & 0xFu) };
     out_inst.type = inst_type::MUL_ACCUM_UNSIGNED_LONG;
     out_inst.dr = u16((1u << dlo) | (1u << dhi));
-    out_inst.i.mul_accum_unsigned_long = { .dlo = dlo, .dhi = dhi, .n = u8(w0 & 0xFu),
-      .m = u8(w1 & 0xFu) };
+    out_inst.i.mul_accum_unsigned_long = { .dlo = dlo,
+                                           .dhi = dhi,
+                                           .n = u8(w0 & 0xFu),
+                                           .m = u8(w1 & 0xFu) };
     return true;
   }
 
@@ -1663,25 +1821,28 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
   if (((w0 & 0xFFF0u) == 0xFBA0u) && ((w1 & 0xF0u) == 0)) {
     out_inst.type = inst_type::MUL_UNSIGNED_LONG;
     out_inst.i.mul_unsigned_long = { .dlo = u8((w1 >> 12u) & 0xFu),
-      .dhi = u8((w1 >> 8u) & 0xFu), .n = u8(w0 & 0xFu), .m = u8(w1 & 0xFu) };
+                                     .dhi = u8((w1 >> 8u) & 0xFu),
+                                     .n = u8(w0 & 0xFu),
+                                     .m = u8(w1 & 0xFu) };
     return true;
   }
 
   // 4.6.216 USAT, T1 encoding (pg 4-445)
   if (((w0 & 0xFBD0u) == 0xF380u) && ((w1 & 0x8000u) == 0)) {
-    u8 const imm2{u8((w1 >> 6u) & 3u)}, imm3{u8((w1 >> 12u) & 7u)},
-      imm5{u8((imm3 << 2u) | imm2)}, sh{u8((w0 >> 5u) & 1u)};
+    u8 const imm2{ u8((w1 >> 6u) & 3u) }, imm3{ u8((w1 >> 12u) & 7u) },
+        imm5{ u8((imm3 << 2u) | imm2) }, sh{ u8((w0 >> 5u) & 1u) };
     out_inst.type = inst_type::SATURATE_UNSIGNED;
     out_inst.dr = u16(1u << ((w1 >> 8) & 0xFu));
     out_inst.i.saturate_unsigned = { .shift = decode_imm_shift(u8(sh << 1u), imm5),
-      .n = u8(w0 & 0xFu), .saturate_to = u8(w1 & 0x1Fu) };
+                                     .n = u8(w0 & 0xFu),
+                                     .saturate_to = u8(w1 & 0x1Fu) };
     return true;
   }
 
   // 4.6.221 UXTAB, T1 encoding (pg 4-455)
   if (((w0 & 0xFFF0u) == 0xFA50u) && ((w1 & 0xF080u) == 0xF080u)) {
-    u8 const d{u8((w1 >> 8u) & 0xFu)}, n{u8(w0 & 0xFu)}, m{u8(w1 & 0xFu)},
-      rotation{u8(((w1 >> 4u) & 3u) << 3u)};
+    u8 const d{ u8((w1 >> 8u) & 0xFu) }, n{ u8(w0 & 0xFu) }, m{ u8(w1 & 0xFu) },
+        rotation{ u8(((w1 >> 4u) & 3u) << 3u) };
     if (n == 15) {  // 4.6.224 UXTB, T2 encoding (pg 4-461)
       out_inst.type = inst_type::EXTEND_UNSIGNED_BYTE;
       out_inst.dr = u16(1u << d);
@@ -1696,9 +1857,9 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // 4.6.223 UXTAH, T1 encoding (pg 4-459)
   if (((w0 & 0xFFF0u) == 0xFA10u) && ((w1 & 0xF080u) == 0xF080u)) {
-    u8 const n{u8(w0 & 0xFu)}, d{u8((w1 >> 8u) & 0xFu)}, m{u8(w1 & 0xFu)},
-      rotation{u8(((w1 >> 4u) & 3u) << 3u)};
-    if (n == 15) { // 4.6.226 UXTH, T2 encoding (pg 4-465)
+    u8 const n{ u8(w0 & 0xFu) }, d{ u8((w1 >> 8u) & 0xFu) }, m{ u8(w1 & 0xFu) },
+        rotation{ u8(((w1 >> 4u) & 3u) << 3u) };
+    if (n == 15) {  // 4.6.226 UXTH, T2 encoding (pg 4-465)
       out_inst.type = inst_type::EXTEND_UNSIGNED_HALF;
       out_inst.dr = u16(1u << d);
       out_inst.i.extend_unsigned_half = { .m = m, .rotation = rotation };
@@ -1712,74 +1873,88 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // A7.7.221 VADD, T1 encoding (pg A7-566)
   if (((w0 & 0xFFB0u) == 0xEE30u) && ((w1 & 0xF50u) == 0xA00u)) {
-    u8 const D{u8((w0 >> 6u) & 1u)}, N{u8((w1 >> 7u) & 1u)}, M{u8((w1 >> 5u) & 1u)},
-      vn{u8(w0 & 0xFu)}, vm{u8(w1 & 0xFu)}, vd{u8((w1 >> 12u) & 0xFu)};
+    u8 const D{ u8((w0 >> 6u) & 1u) }, N{ u8((w1 >> 7u) & 1u) }, M{ u8((w1 >> 5u) & 1u) },
+        vn{ u8(w0 & 0xFu) }, vm{ u8(w1 & 0xFu) }, vd{ u8((w1 >> 12u) & 0xFu) };
     out_inst.type = inst_type::VADD;
-    out_inst.i.vadd = { .d = u8((vd << 1u) | D), .n = u8((vn << 1u) | N),
-      .m = u8((vm << 1u) | M) };
+    out_inst.i.vadd = { .d = u8((vd << 1u) | D),
+                        .n = u8((vn << 1u) | N),
+                        .m = u8((vm << 1u) | M) };
     return true;
   }
 
   // A7.7.222 VCMP, T1 encoding (pg A7-567)
   if (((w0 & 0xFFBFu) == 0xEEB4u) && ((w1 & 0xF50u) == 0xA40u)) {
-    u8 const D{u8((w0 >> 6u) & 1u)}, vd{u8((w1 >> 12u) & 0xFu)}, vm{u8(w1 & 0xFu)},
-      M{u8((w1 >> 5u) & 1u)};
+    u8 const D{ u8((w0 >> 6u) & 1u) }, vd{ u8((w1 >> 12u) & 0xFu) }, vm{ u8(w1 & 0xFu) },
+        M{ u8((w1 >> 5u) & 1u) };
     out_inst.type = inst_type::VCOMPARE;
-    out_inst.i.vcompare = { .quiet_nan_exc = u8((w1 >> 7u) & 1u), .with_zero = 0u,
-      .d = u8((vd << 1u) | D), .m = u8((vm << 1u) | M) };
+    out_inst.i.vcompare = { .quiet_nan_exc = u8((w1 >> 7u) & 1u),
+                            .with_zero = 0u,
+                            .d = u8((vd << 1u) | D),
+                            .m = u8((vm << 1u) | M) };
     return true;
   }
 
   // A7.7.222 VCMP, T2 encoding (pg A7-567)
   if (((w0 & 0xFFBFu) == 0xEEB5u) && ((w1 & 0xF50u) == 0xA40u)) {
-    u8 const D{u8((w0 >> 6u) & 1u)}, vd{u8((w1 >> 12u) & 0xFu)};
+    u8 const D{ u8((w0 >> 6u) & 1u) }, vd{ u8((w1 >> 12u) & 0xFu) };
     out_inst.type = inst_type::VCOMPARE;
-    out_inst.i.vcompare = { .quiet_nan_exc = u8((w1 >> 7u) & 1u), .with_zero = 1u,
-      .d = u8((vd << 1u) | D), .m = 0 };
+    out_inst.i.vcompare = { .quiet_nan_exc = u8((w1 >> 7u) & 1u),
+                            .with_zero = 1u,
+                            .d = u8((vd << 1u) | D),
+                            .m = 0 };
     return true;
   }
 
   // A7.7.223 VCVT (between FP and int), T1 encoding (pg A7-569)
   if (((w0 & 0xFFB8u) == 0xEEB8u) && ((w1 & 0xF50u) == 0xA40u)) {
-    u8 const opc2{u8(w0 & 7u)}, d{u8(((w1 >> 11u) & 0x1Eu) | ((w0 >> 6u) & 1u))},
-      op{u8((w1 >> 7u) & 1u)}, m{u8(((w1 & 0xFu) << 1u) | ((w1 >> 5u) & 1u))},
-      to_int{u8(!!(opc2 & 0b100))};
+    u8 const opc2{ u8(w0 & 7u) }, d{ u8(((w1 >> 11u) & 0x1Eu) | ((w0 >> 6u) & 1u)) },
+        op{ u8((w1 >> 7u) & 1u) }, m{ u8(((w1 & 0xFu) << 1u) | ((w1 >> 5u) & 1u)) },
+        to_int{ u8(!!(opc2 & 0b100)) };
     out_inst.type = inst_type::VCONVERT_FP_INT;
     if (to_int) {
-      out_inst.i.vconvert_fp_int = { .d = d, .m = m, .to_int = to_int,
-        .int_unsigned = ((opc2 & 1u) == 0), .round_zero = op };
+      out_inst.i.vconvert_fp_int = { .d = d,
+                                     .m = m,
+                                     .to_int = to_int,
+                                     .int_unsigned = ((opc2 & 1u) == 0),
+                                     .round_zero = op };
     } else {
-      out_inst.i.vconvert_fp_int = { .d = d, .m = m, .to_int = to_int,
-        .int_unsigned = (op == 0), .round_zero = 0 };
+      out_inst.i.vconvert_fp_int = { .d = d,
+                                     .m = m,
+                                     .to_int = to_int,
+                                     .int_unsigned = (op == 0),
+                                     .round_zero = 0 };
     }
     return true;
   }
 
   // A7.7.226 VDIV, T1 encoding (pg A7-575)
   if (((w0 & 0xFFB0u) == 0xEE80u) && ((w1 & 0xF50u) == 0xA00u)) {
-    u8 const vm{u8(w1 & 0xFu)}, vn{u8(w0 & 0xFu)}, vd{u8((w1 >> 12u) & 1u)},
-      D{u8((w0 >> 6u) & 1u)}, N{u8((w1 >> 7u) & 1u)}, M{u8((w1 >> 5u) & 1u)};
+    u8 const vm{ u8(w1 & 0xFu) }, vn{ u8(w0 & 0xFu) }, vd{ u8((w1 >> 12u) & 1u) },
+        D{ u8((w0 >> 6u) & 1u) }, N{ u8((w1 >> 7u) & 1u) }, M{ u8((w1 >> 5u) & 1u) };
     out_inst.type = inst_type::VDIV;
-    out_inst.i.vdiv = { .d = u8((vd << 1u) | D), .n = u8((vn << 1u) | N),
-      .m = u8((vm << 1u) | M) };
+    out_inst.i.vdiv = { .d = u8((vd << 1u) | D),
+                        .n = u8((vn << 1u) | N),
+                        .m = u8((vm << 1u) | M) };
     return true;
   }
 
   // A7.7.227 VFMA, VFMS, T1 encoding (pg A7-576)
   if (((w0 & 0xFFB0u) == 0xEEA0u) && ((w1 & 0xF10u) == 0xA00u)) {
-    u8 const vn{u8(w0 & 0xFu)}, vm{u8(w1 & 0xFu)}, vd{u8((w1 >> 12u) & 0xFu)},
-      N{u8((w1 >> 7u) & 1u)}, M{u8((w1 >> 5u) & 1u)}, D{u8((w0 >> 6u) & 1u)};
+    u8 const vn{ u8(w0 & 0xFu) }, vm{ u8(w1 & 0xFu) }, vd{ u8((w1 >> 12u) & 0xFu) },
+        N{ u8((w1 >> 7u) & 1u) }, M{ u8((w1 >> 5u) & 1u) }, D{ u8((w0 >> 6u) & 1u) };
     out_inst.type = inst_type::VMULT_ACCUM;
-    out_inst.i.vmult_accum = { .op1_neg = u8((w1 >> 6u) & 1u), .d = u8((vd << 1u) | D),
-      .n = u8((vn << 1u) | N), .m = u8((vm << 1u) | M) };
+    out_inst.i.vmult_accum = { .op1_neg = u8((w1 >> 6u) & 1u),
+                               .d = u8((vd << 1u) | D),
+                               .n = u8((vn << 1u) | N),
+                               .m = u8((vm << 1u) | M) };
     return true;
   }
 
   // A7.7.229 VLDM, T2 encoding (pg A7-579)
   if (((w0 & 0xFE10u) == 0xEC10u) && ((w1 & 0xF00u) == 0xA00u)) {
-    u8 const p{u8((w0 >> 8u) & 1u)}, u{u8((w0 >> 7u) & 1u)}, w{u8((w0 >> 5u) & 1u)},
-      n{u8(w0 & 0xFu)}, imm8{u8(w1 & 0xFFu)}, D{u8((w0 >> 6u) & 1u)},
-      vd{u8((w1 >> 12u) & 0xFu)};
+    u8 const p{ u8((w0 >> 8u) & 1u) }, u{ u8((w0 >> 7u) & 1u) }, w{ u8((w0 >> 5u) & 1u) },
+        n{ u8(w0 & 0xFu) }, imm8{ u8(w1 & 0xFFu) }, D{ u8((w0 >> 6u) & 1u) },
+        vd{ u8((w1 >> 12u) & 0xFu) };
     if ((p == 0) && (u == 0) && (w == 0)) {
       printf("See 64-bit transfers ... on page A6-199\n");
       return false;
@@ -1788,32 +1963,41 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
       printf("SEE VPOP\n");
       return false;
     }
-    if ((p == 1) && (w == 0)) { // A7.7.230 VLDR, T2 encoding (pg A7-581)
+    if ((p == 1) && (w == 0)) {  // A7.7.230 VLDR, T2 encoding (pg A7-581)
       out_inst.type = inst_type::VLOAD;
-      out_inst.i.vload = { .imm = u16(imm8 << 2u), .single_reg = 1u,
-        .add = u8((w0 >> 7u) & 1u), .n = u8(w0 & 0xFu), .d = u8((vd << 1) | D) };
+      out_inst.i.vload = { .imm = u16(imm8 << 2u),
+                           .single_reg = 1u,
+                           .add = u8((w0 >> 7u) & 1u),
+                           .n = u8(w0 & 0xFu),
+                           .d = u8((vd << 1) | D) };
       return true;
     }
     out_inst.type = inst_type::VLOAD_MULT;
-    out_inst.i.vload_mult = { .imm = u32(imm8 << 2u), .d = u8((vd << 1) | D), .n = n,
-      .wback = w, .regs = imm8, .single_regs = 1u, .add = u };
+    out_inst.i.vload_mult = { .imm = u32(imm8 << 2u),
+                              .d = u8((vd << 1) | D),
+                              .n = n,
+                              .wback = w,
+                              .regs = imm8,
+                              .single_regs = 1u,
+                              .add = u };
     return true;
   }
 
   // A7.7.232 VMOV (imm), T1 encoding (pg A7-585)
   if (((w0 & 0xFFB0u) == 0xEEB0u) && ((w1 & 0xF50u) == 0xA00u)) {
-    u8 const imm4h{u8(w0 & 0xFu)}, imm4l{u8(w1 & 0xFu)}, vd{u8((w1 >> 12u) & 0xFu)},
-      D{u8((w0 >> 6u) & 1u)};
+    u8 const imm4h{ u8(w0 & 0xFu) }, imm4l{ u8(w1 & 0xFu) }, vd{ u8((w1 >> 12u) & 0xFu) },
+        D{ u8((w0 >> 6u) & 1u) };
     out_inst.type = inst_type::VMOV_IMM;
     out_inst.i.vmov_imm = { .imm = decode_vfp_imm8(u8((imm4h << 4u) | imm4l), 32),
-      .d = u8((D << 4u) | vd), .regs = 1u };
+                            .d = u8((D << 4u) | vd),
+                            .regs = 1u };
     return true;
   }
 
   // A7.7.233 VMOV (reg), T1 encoding (pg A7-586)
   if (((w0 & 0xFFBFu) == 0xEEB0u) && ((w1 & 0xFD0u) == 0xA40u)) {
-    u8 const vm{u8(w1 & 0xFu)}, vd{u8((w1 >> 12u) & 0xFu)}, M{u8((w1 >> 5u) & 1u)},
-      D{u8((w0 >> 6u) & 1u)};
+    u8 const vm{ u8(w1 & 0xFu) }, vd{ u8((w1 >> 12u) & 0xFu) }, M{ u8((w1 >> 5u) & 1u) },
+        D{ u8((w0 >> 6u) & 1u) };
     out_inst.type = inst_type::VMOV_REG;
     out_inst.i.vmov_reg = { .d = u8((vd << 1u) | D), .m = u8((vm << 1u) | M) };
     return true;
@@ -1821,11 +2005,16 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // A7.7.237 VMOV (2 ARM core regsters and a dword reg), T1 encoding (pg A7-590)
   if (((w0 & 0xFFE0u) == 0xEC40u) && ((w1 & 0xFD0u) == 0xB10u)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, t2{u8(w0 & 0xFu)}, to_arm_regs{u8((w0 >> 4u) & 1u)};
-    if (to_arm_regs) { out_inst.dr = u16((1u << t) | (1u << t2)); }
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, t2{ u8(w0 & 0xFu) },
+        to_arm_regs{ u8((w0 >> 4u) & 1u) };
+    if (to_arm_regs) {
+      out_inst.dr = u16((1u << t) | (1u << t2));
+    }
     out_inst.type = inst_type::VMOV_REG_DOUBLE;
-    out_inst.i.vmov_reg_double = { .t = t, .t2 = t2,
-      .m = u8((w1 & 0xFu) | ((w1 >> 1u) & 0x10u)), .to_arm_regs = to_arm_regs };
+    out_inst.i.vmov_reg_double = { .t = t,
+                                   .t2 = t2,
+                                   .m = u8((w1 & 0xFu) | ((w1 >> 1u) & 0x10u)),
+                                   .to_arm_regs = to_arm_regs };
     return true;
   }
 
@@ -1845,28 +2034,32 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // A7.7.236 VMOV (ARM core reg and single-precision reg), T1 encoding (pg A7-531)
   if (((w0 & 0xFFE0u) == 0xEE00u) && ((w1 & 0xF10u) == 0xA10u)) {
-    u8 const t{u8((w1 >> 12u) & 0xFu)}, to_arm_reg{u8((w0 >> 4u) & 1u)};
+    u8 const t{ u8((w1 >> 12u) & 0xFu) }, to_arm_reg{ u8((w0 >> 4u) & 1u) };
     out_inst.type = inst_type::VMOV_REG_SINGLE;
-    if (to_arm_reg) { out_inst.dr = u16(1u << t); }
+    if (to_arm_reg) {
+      out_inst.dr = u16(1u << t);
+    }
     out_inst.i.vmov_reg_single = { .t = t,
-      .n = u8(((w0 & 0xFu) << 1u) | ((w1 >> 7u) & 1u)), .to_arm_reg = to_arm_reg };
+                                   .n = u8(((w0 & 0xFu) << 1u) | ((w1 >> 7u) & 1u)),
+                                   .to_arm_reg = to_arm_reg };
     return true;
   }
 
   // A7.7.241 VMUL, T1 encoding (pg A7-594)
   if (((w0 & 0xFFB0u) == 0xEE20u) && ((w1 & 0xF50u) == 0xA00u)) {
-    u8 const D{u8((w0 >> 6u) & 1u)}, N{u8((w1 >> 7u) & 1u)}, M{u8((w1 >> 5u) & 1u)},
-      vd{u8((w1 >> 12u) & 0xFu)}, vm{u8(w1 & 0xFu)}, vn{u8(w0 & 0xFu)};
+    u8 const D{ u8((w0 >> 6u) & 1u) }, N{ u8((w1 >> 7u) & 1u) }, M{ u8((w1 >> 5u) & 1u) },
+        vd{ u8((w1 >> 12u) & 0xFu) }, vm{ u8(w1 & 0xFu) }, vn{ u8(w0 & 0xFu) };
     out_inst.type = inst_type::VMUL;
-    out_inst.i.vmul = { .d = u8((vd << 1u) | D), .n = u8((vn << 1u) | N),
-      .m = u8((vm << 1u) | M) };
+    out_inst.i.vmul = { .d = u8((vd << 1u) | D),
+                        .n = u8((vn << 1u) | N),
+                        .m = u8((vm << 1u) | M) };
     return true;
   }
 
   // A7.7.242 VNEG, T1 encoding (pg A7-595)
   if (((w0 & 0xFFBFu) == 0xEEB1u) && ((w1 & 0xFD0u) == 0xA40u)) {
-    u8 const vm{u8(w1 & 0xFu)}, vd{u8((w1 >> 12u) & 0xFu)}, D{u8((w0 >> 6u) & 1u)},
-      M{u8((w1 >> 5u) & 1u)};
+    u8 const vm{ u8(w1 & 0xFu) }, vd{ u8((w1 >> 12u) & 0xFu) }, D{ u8((w0 >> 6u) & 1u) },
+        M{ u8((w1 >> 5u) & 1u) };
     out_inst.type = inst_type::VNEG;
     out_inst.i.vneg = { .d = u8((vd << 1u) | D), .m = u8((vm << 1u) | M) };
     return true;
@@ -1874,28 +2067,32 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // A7.7.244 VPOP, T1 encoding (pg A7-599)
   if (((w0 & 0xFFBFu) == 0xECBDu) && ((w1 & 0xF00u) == 0xB00u)) {
-    u8 const vd{u8((w1 >> 12u) & 0xFu)}, D{u8((w0 >> 6u) & 1u)};
-    u16 const imm8{u16(w1 & 0xFFu)};
+    u8 const vd{ u8((w1 >> 12u) & 0xFu) }, D{ u8((w0 >> 6u) & 1u) };
+    u16 const imm8{ u16(w1 & 0xFFu) };
     out_inst.type = inst_type::VPOP;
-    out_inst.i.vpop = { .imm = u16(imm8 << 2u), .d = u8((D << 4u) | vd),
-      .single_regs = 0, .regs = u8(imm8 / 2) };
+    out_inst.i.vpop = { .imm = u16(imm8 << 2u),
+                        .d = u8((D << 4u) | vd),
+                        .single_regs = 0,
+                        .regs = u8(imm8 / 2) };
     return true;
   }
 
   // A7.7.245 VPUSH, T2 encoding (pg A7-601)
   if (((w0 & 0xFFBFu) == 0xED2Du) && ((w1 & 0xF00u) == 0xB00u)) {
-    u8 const vd{u8((w1 >> 12u) & 0xFu)}, D{u8((w0 >> 6u) & 1u)};
-    u16 const imm8{u16(w1 & 0xFFu)};
+    u8 const vd{ u8((w1 >> 12u) & 0xFu) }, D{ u8((w0 >> 6u) & 1u) };
+    u16 const imm8{ u16(w1 & 0xFFu) };
     out_inst.type = inst_type::VPUSH;
-    out_inst.i.vpush = { .imm = u16(imm8 << 2u), .d = u8((D << 4u) | vd),
-      .single_regs = 0, .regs = u8(imm8 / 2) };
+    out_inst.i.vpush = { .imm = u16(imm8 << 2u),
+                         .d = u8((D << 4u) | vd),
+                         .single_regs = 0,
+                         .regs = u8(imm8 / 2) };
     return true;
   }
 
   // A7.7.246 VSQRT, T1 encoding (pg A7-603)
   if (((w0 & 0xFFBFu) == 0xEEB1u) && ((w1 & 0xFD0u) == 0xAC0u)) {
-    u8 const vm{u8(w1 & 0xFu)}, vd{u8((w1 >> 12u) & 0xFu)}, M{u8((w1 >> 5u) & 1u)},
-      D{u8((w0 >> 6u) & 1u)};
+    u8 const vm{ u8(w1 & 0xFu) }, vd{ u8((w1 >> 12u) & 0xFu) }, M{ u8((w1 >> 5u) & 1u) },
+        D{ u8((w0 >> 6u) & 1u) };
     out_inst.type = inst_type::VSQRT;
     out_inst.i.vsqrt = { .d = u8((vd << 1u) | D), .m = u8((vm << 1u) | M) };
     return true;
@@ -1903,9 +2100,9 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
 
   // A7.7.247 VSTM, T2 encoding (pg A7-605)
   if (((w0 & 0xFE10u) == 0xEC00u) && ((w1 & 0xF00u) == 0xA00u)) {
-    u8 const n{u8(w0 & 0xFu)}, vd{u8((w1 >> 12u) & 0xFu)}, D{u8((w1 >> 6u) & 1u)},
-      imm{u8(w1 & 0xFFu)}, p{u8((w0 >> 8u) & 1u)}, u{u8((w0 >> 7u) & 1u)},
-      w{u8((w0 >> 5u) & 1u)};
+    u8 const n{ u8(w0 & 0xFu) }, vd{ u8((w1 >> 12u) & 0xFu) }, D{ u8((w1 >> 6u) & 1u) },
+        imm{ u8(w1 & 0xFFu) }, p{ u8((w0 >> 8u) & 1u) }, u{ u8((w0 >> 7u) & 1u) },
+        w{ u8((w0 >> 5u) & 1u) };
     if ((p == 0) && (u == 0) && (w == 0)) {
       printf("See 64-bit transfers ... on page A6-199\n");
       return false;
@@ -1919,38 +2116,49 @@ bool decode_32bit_inst(u16 const w0, u16 const w1, inst& out_inst) {
       return false;
     }
     out_inst.type = inst_type::VSTORE_MULT;
-    out_inst.i.vstore_mult = { .imm = u16(imm << 2u), .n = n, .d = u8((vd << 1u) | D),
-      .list = imm, .wb = w, .single_regs = 1u, .add = u };
+    out_inst.i.vstore_mult = { .imm = u16(imm << 2u),
+                               .n = n,
+                               .d = u8((vd << 1u) | D),
+                               .list = imm,
+                               .wb = w,
+                               .single_regs = 1u,
+                               .add = u };
     return true;
   }
 
   // A7.7.248 VSTR, T2 encoding (pg A7-607)
   if (((w0 & 0xFF30u) == 0xED00u) && ((w1 & 0xF00u) == 0xA00u)) {
-    u8 const D{u8((w0 >> 6u) & 1u)}, vd{u8((w1 >> 12u) & 0xFu)};
-    u16 const imm8{u16(w1 & 0xFFu)};
+    u8 const D{ u8((w0 >> 6u) & 1u) }, vd{ u8((w1 >> 12u) & 0xFu) };
+    u16 const imm8{ u16(w1 & 0xFFu) };
     out_inst.type = inst_type::VSTORE;
-    out_inst.i.vstore = { .imm = u16(imm8 << 2u), .single_reg = 1u,
-      .add = u8((w0 >> 7u) & 1u), .d = u8((vd << 1u) | D), .n = u8(w0 & 0xFu) };
+    out_inst.i.vstore = { .imm = u16(imm8 << 2u),
+                          .single_reg = 1u,
+                          .add = u8((w0 >> 7u) & 1u),
+                          .d = u8((vd << 1u) | D),
+                          .n = u8(w0 & 0xFu) };
     return true;
   }
 
   // A7.7.249 VSUB, T1 encoding (pg  A7-609)
   if (((w0 & 0xFFB0u) == 0xEE30u) && ((w1 & 0xF50u) == 0xA40u)) {
-    u8 const vm{u8(w1 & 0xFu)}, vn{u8(w0 & 0xFu)}, M{u8((w1 >> 5u) & 1u)},
-      N{u8((w1 >> 7u) & 1u)}, D{u8((w0 >> 6u) & 1u)}, vd{u8((w1 >> 12u) & 0xFu)};
+    u8 const vm{ u8(w1 & 0xFu) }, vn{ u8(w0 & 0xFu) }, M{ u8((w1 >> 5u) & 1u) },
+        N{ u8((w1 >> 7u) & 1u) }, D{ u8((w0 >> 6u) & 1u) }, vd{ u8((w1 >> 12u) & 0xFu) };
     out_inst.type = inst_type::VSUB;
-    out_inst.i.vsub = { .d = u8((vd << 1) | D), .n = u8((vn << 1u) | N),
-      .m = u8((vm << 1u) | M) };
+    out_inst.i.vsub = { .d = u8((vd << 1) | D),
+                        .n = u8((vn << 1u) | N),
+                        .m = u8((vm << 1u) | M) };
     return true;
   }
 
   return false;
 }
 
-}
+}  // namespace
 
 int inst_reg_from_bitmask(uint16_t reg_bitmask) {
-  if (!reg_bitmask) { return -1; }
+  if (!reg_bitmask) {
+    return -1;
+  }
 #ifdef _MSC_VER
   DWORD idx;
   _BitScanForward(&idx, reg_bitmask);
@@ -1963,144 +2171,191 @@ int inst_reg_from_bitmask(uint16_t reg_bitmask) {
 bool inst_is_unconditional_branch(inst const& i, u32& label) {
   switch (i.type) {
     case inst_type::BRANCH:
-      label = i.i.branch.addr; return cond_code_is_always(i.i.branch.cc);
-    case inst_type::BRANCH_XCHG: label = 0; return true;
-    case inst_type::BRANCH_LINK: label = i.i.branch_link.addr; return true;
-    case inst_type::BRANCH_LINK_XCHG_REG: label = 0; return true; // TODO: register state
-    default: break;
+      label = i.i.branch.addr;
+      return cond_code_is_always(i.i.branch.cc);
+    case inst_type::BRANCH_XCHG:
+      label = 0;
+      return true;
+    case inst_type::BRANCH_LINK:
+      label = i.i.branch_link.addr;
+      return true;
+    case inst_type::BRANCH_LINK_XCHG_REG:
+      label = 0;
+      return true;  // TODO: register state
+    default:
+      break;
   }
   return false;
 }
 
-u32 inst_align(u32 val, u32 align) { // Rounding and Aligning, A-16
+u32 inst_align(u32 val, u32 align) {  // Rounding and Aligning, A-16
   // If x and y are integers, Align(x,y) = y * (x DIV y) is an integer.
   return align * (val / align);
 }
 
-bool inst_decode(byte const *text, u32 func_addr, u32 pc_addr, inst& out_inst) {
+bool inst_decode(byte const* text, u32 func_addr, u32 pc_addr, inst& out_inst) {
   out_inst.type = inst_type::UNKNOWN;
   out_inst.addr = func_addr + pc_addr;
   out_inst.dr = 0;
   out_inst.w1 = 0;
 
   memcpy(&out_inst.w0, &text[pc_addr], 2);
-  if (is_16bit_inst(out_inst.w0)) { return decode_16bit_inst(out_inst.w0, out_inst); }
+  if (is_16bit_inst(out_inst.w0)) {
+    return decode_16bit_inst(out_inst.w0, out_inst);
+  }
   memcpy(&out_inst.w1, &text[pc_addr + 2], 2);
   return decode_32bit_inst(out_inst.w0, out_inst.w1, out_inst);
 }
 
-char const *reg_name(int reg) {
-  if ((reg < 0) || (reg > 15)) { return "<invalid>"; }
+char const* reg_name(int reg) {
+  if ((reg < 0) || (reg > 15)) {
+    return "<invalid>";
+  }
   return s_rn[reg];
 }
 
 namespace {
-char const *rn_mask(uint16_t dr) {
-  if (!dr) { return "<invalid>"; }
+char const* rn_mask(uint16_t dr) {
+  if (!dr) {
+    return "<invalid>";
+  }
   return reg_name(inst_reg_from_bitmask(dr));
 }
-}
+}  // namespace
 
 void inst_print(inst const& i) {
   switch (i.type) {
-    case inst_type::UNKNOWN: NL_LOG_DBG("??"); break;
+    case inst_type::UNKNOWN:
+      NL_LOG_DBG("??");
+      break;
 
     case inst_type::ADD_CARRY_IMM: {
-      auto const& a{i.i.add_carry_imm};
+      auto const& a{ i.i.add_carry_imm };
       NL_LOG_DBG("ADC_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[a.n], int(a.imm));
     } break;
 
     case inst_type::ADD_CARRY_REG: {
-      auto const& a{i.i.add_carry_reg};
-      NL_LOG_DBG("ADC_REG %s, %s, %s <%s #%d>", rn_mask(i.dr), s_rn[a.n], s_rn[a.m],
-        s_sn[int(a.shift.t)], int(a.shift.n));
+      auto const& a{ i.i.add_carry_reg };
+      NL_LOG_DBG("ADC_REG %s, %s, %s <%s #%d>",
+                 rn_mask(i.dr),
+                 s_rn[a.n],
+                 s_rn[a.m],
+                 s_sn[int(a.shift.t)],
+                 int(a.shift.n));
     } break;
 
     case inst_type::ADD_IMM: {
-      auto const& a{i.i.add_imm};
+      auto const& a{ i.i.add_imm };
       NL_LOG_DBG("ADD_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[a.n], int(a.imm));
     } break;
 
     case inst_type::ADD_SP_IMM: {
-      auto const& a{i.i.add_sp_imm};
+      auto const& a{ i.i.add_sp_imm };
       NL_LOG_DBG("ADD %s, [%s, #%d]", rn_mask(i.dr), s_rn[reg::SP], (int)a.imm);
     } break;
 
     case inst_type::ADD_SP_REG: {
-      auto const& a{i.i.add_sp_reg};
-      NL_LOG_DBG("ADD %s, %s, %s <%s, #%d>", rn_mask(i.dr), s_rn[reg::SP], s_rn[a.m],
-        s_sn[int(a.shift.t)], int(a.shift.n));
+      auto const& a{ i.i.add_sp_reg };
+      NL_LOG_DBG("ADD %s, %s, %s <%s, #%d>",
+                 rn_mask(i.dr),
+                 s_rn[reg::SP],
+                 s_rn[a.m],
+                 s_sn[int(a.shift.t)],
+                 int(a.shift.n));
     } break;
 
     case inst_type::ADD_REG: {
-      auto const& a{i.i.add_reg};
-      NL_LOG_DBG("ADD_REG %s, %s, %s <%s #%d>", rn_mask(i.dr), s_rn[a.n], s_rn[a.m],
-        s_sn[int(a.shift.t)], int(a.shift.n));
+      auto const& a{ i.i.add_reg };
+      NL_LOG_DBG("ADD_REG %s, %s, %s <%s #%d>",
+                 rn_mask(i.dr),
+                 s_rn[a.n],
+                 s_rn[a.m],
+                 s_sn[int(a.shift.t)],
+                 int(a.shift.n));
     } break;
 
     case inst_type::ADD_8_UNSIGNED: {
-      auto const& a{i.i.add_8_unsigned};
+      auto const& a{ i.i.add_8_unsigned };
       NL_LOG_DBG("UADD8 %s, %s, %s", rn_mask(i.dr), s_rn[a.n], s_rn[a.m]);
     } break;
 
     case inst_type::ADR: {
-      auto const& a{i.i.adr};
+      auto const& a{ i.i.adr };
       NL_LOG_DBG("ADR %s, PC, #%c%d", rn_mask(i.dr), a.add ? '+' : '-', (int)a.imm);
     } break;
 
     case inst_type::AND_REG: {
-      auto const& a{i.i.and_reg};
-      NL_LOG_DBG("AND_REG %s, %s, %s <%s #%d>", rn_mask(i.dr), s_rn[a.n], s_rn[a.m],
-        s_sn[int(a.shift.t)], int(a.shift.n));
+      auto const& a{ i.i.and_reg };
+      NL_LOG_DBG("AND_REG %s, %s, %s <%s #%d>",
+                 rn_mask(i.dr),
+                 s_rn[a.n],
+                 s_rn[a.m],
+                 s_sn[int(a.shift.t)],
+                 int(a.shift.n));
     } break;
 
     case inst_type::AND_IMM: {
-      auto const& a{i.i.and_imm};
+      auto const& a{ i.i.and_imm };
       NL_LOG_DBG("AND_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[a.n], int(a.imm));
     } break;
 
     case inst_type::BIT_CLEAR_IMM: {
-      auto const& b{i.i.bit_clear_imm};
+      auto const& b{ i.i.bit_clear_imm };
       NL_LOG_DBG("BIC_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[b.n], int(b.imm));
     } break;
 
     case inst_type::BIT_CLEAR_REG: {
-      auto const& b{i.i.bit_clear_reg};
-      NL_LOG_DBG("BIC_REG %s, %s, %s, <%s #%d>", rn_mask(i.dr), s_rn[b.n], s_rn[b.m],
-        s_sn[int(b.shift.t)], int(b.shift.n));
+      auto const& b{ i.i.bit_clear_reg };
+      NL_LOG_DBG("BIC_REG %s, %s, %s, <%s #%d>",
+                 rn_mask(i.dr),
+                 s_rn[b.n],
+                 s_rn[b.m],
+                 s_sn[int(b.shift.t)],
+                 int(b.shift.n));
     } break;
 
     case inst_type::BITFIELD_CLEAR: {
-      auto const& b{i.i.bitfield_clear};
+      auto const& b{ i.i.bitfield_clear };
       NL_LOG_DBG("BFC %s, #%d, #%d", s_rn[b.d], int(b.lsbit), int(b.msbit - b.lsbit));
     } break;
 
     case inst_type::BITFIELD_EXTRACT_UNSIGNED: {
-      auto const& b{i.i.bitfield_extract_unsigned};
-      NL_LOG_DBG("UBFX %s, %s, #%d, #%d", rn_mask(i.dr), s_rn[b.n], int(b.lsbit),
-        int(b.widthminus1 + 1));
+      auto const& b{ i.i.bitfield_extract_unsigned };
+      NL_LOG_DBG("UBFX %s, %s, #%d, #%d",
+                 rn_mask(i.dr),
+                 s_rn[b.n],
+                 int(b.lsbit),
+                 int(b.widthminus1 + 1));
     } break;
 
     case inst_type::BITFIELD_EXTRACT_SIGNED: {
-      auto const& b{i.i.bitfield_extract_signed};
-      NL_LOG_DBG("SBFX %s, %s, #%d, #%d", rn_mask(i.dr), s_rn[b.n], int(b.lsbit),
-        int(b.widthminus1 + 1));
+      auto const& b{ i.i.bitfield_extract_signed };
+      NL_LOG_DBG("SBFX %s, %s, #%d, #%d",
+                 rn_mask(i.dr),
+                 s_rn[b.n],
+                 int(b.lsbit),
+                 int(b.widthminus1 + 1));
     } break;
 
     case inst_type::BITFIELD_INSERT: {
-      auto const& b{i.i.bitfield_insert};
-      NL_LOG_DBG("BFI %s, %s, #%d, #%d", rn_mask(i.dr), s_rn[b.n], int(b.lsbit),
-        int(b.msbit - b.lsbit));
+      auto const& b{ i.i.bitfield_insert };
+      NL_LOG_DBG("BFI %s, %s, #%d, #%d",
+                 rn_mask(i.dr),
+                 s_rn[b.n],
+                 int(b.lsbit),
+                 int(b.msbit - b.lsbit));
     } break;
 
     case inst_type::BRANCH: {
-      auto const& b{i.i.branch};
-      NL_LOG_DBG("B%s #%d (%x)", b.cc >= cond_code::AL1 ? "" : cond_code_name(b.cc),
-        int(i32(b.imm)), unsigned(b.addr));
+      auto const& b{ i.i.branch };
+      NL_LOG_DBG("B%s #%d (%x)",
+                 b.cc >= cond_code::AL1 ? "" : cond_code_name(b.cc),
+                 int(i32(b.imm)),
+                 unsigned(b.addr));
     } break;
 
     case inst_type::BRANCH_LINK: {
-      auto const& b{i.i.branch_link};
+      auto const& b{ i.i.branch_link };
       NL_LOG_DBG("BL #%d (%x)", unsigned(b.imm), unsigned(b.addr));
     } break;
 
@@ -2129,35 +2384,41 @@ void inst_print(inst const& i) {
       break;
 
     case inst_type::CBNZ: {
-      auto const& c{i.i.cmp_branch_nz};
+      auto const& c{ i.i.cmp_branch_nz };
       NL_LOG_DBG("CBNZ %s, #%d (%x)", s_rn[c.n], unsigned(c.imm), unsigned(c.addr));
     } break;
 
     case inst_type::CBZ: {
-      auto const& c{i.i.cmp_branch_z};
+      auto const& c{ i.i.cmp_branch_z };
       NL_LOG_DBG("CBZ %s, #%d (%x)", s_rn[c.n], unsigned(c.imm), unsigned(c.addr));
     } break;
 
     case inst_type::CHANGE_PROC_STATE: {
-      auto const& c{i.i.change_proc_state};
-      NL_LOG_DBG("CPS%s %s%s%s", c.en ? "IE" : (c.dis ? "ID" : ""),
-        c.aff_a ? "A" : "", c.aff_f ? "F" : "", c.aff_i ? "I" : "");
+      auto const& c{ i.i.change_proc_state };
+      NL_LOG_DBG("CPS%s %s%s%s",
+                 c.en ? "IE" : (c.dis ? "ID" : ""),
+                 c.aff_a ? "A" : "",
+                 c.aff_f ? "F" : "",
+                 c.aff_i ? "I" : "");
     } break;
 
     case inst_type::CMP_IMM: {
-      auto const& c{i.i.cmp_imm};
+      auto const& c{ i.i.cmp_imm };
       NL_LOG_DBG("CMP_IMM %s, #%d", s_rn[c.n], int(c.imm));
     } break;
 
     case inst_type::CMP_NEG_IMM: {
-      auto const& c{i.i.cmp_neg_imm};
+      auto const& c{ i.i.cmp_neg_imm };
       NL_LOG_DBG("CMN_IMM %s, #%d", s_rn[c.n], int(c.imm));
     } break;
 
     case inst_type::CMP_REG: {
-      auto const& c{i.i.cmp_reg};
-      NL_LOG_DBG("CMP_REG %s, %s <%s #%d>", s_rn[c.n], s_rn[c.m], s_sn[int(c.shift.t)],
-        int(c.shift.n));
+      auto const& c{ i.i.cmp_reg };
+      NL_LOG_DBG("CMP_REG %s, %s <%s #%d>",
+                 s_rn[c.n],
+                 s_rn[c.m],
+                 s_sn[int(c.shift.t)],
+                 int(c.shift.n));
     } break;
 
     case inst_type::COUNT_LEADING_ZEROS:
@@ -2165,474 +2426,615 @@ void inst_print(inst const& i) {
       break;
 
     case inst_type::DIV_SIGNED: {
-      auto const& d{i.i.div_signed};
+      auto const& d{ i.i.div_signed };
       NL_LOG_DBG("SDIV %s, %s, %s", rn_mask(i.dr), s_rn[d.n], s_rn[d.m]);
     } break;
 
     case inst_type::DIV_UNSIGNED: {
-      auto const& d{i.i.div_unsigned};
+      auto const& d{ i.i.div_unsigned };
       NL_LOG_DBG("UDIV %s, %s, %s", rn_mask(i.dr), s_rn[d.n], s_rn[d.m]);
     } break;
 
     case inst_type::EXCL_OR_IMM: {
-      auto const& e{i.i.excl_or_imm};
+      auto const& e{ i.i.excl_or_imm };
       NL_LOG_DBG("EOR_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[e.n], int(e.imm));
     } break;
 
     case inst_type::EXCL_OR_REG: {
-      auto const& e{i.i.excl_or_reg};
-      NL_LOG_DBG("EOR_REG %s, %s, %s, <%s #%d>", rn_mask(i.dr), s_rn[e.n], s_rn[e.m],
-        s_sn[int(e.shift.t)], int(e.shift.n));
+      auto const& e{ i.i.excl_or_reg };
+      NL_LOG_DBG("EOR_REG %s, %s, %s, <%s #%d>",
+                 rn_mask(i.dr),
+                 s_rn[e.n],
+                 s_rn[e.m],
+                 s_sn[int(e.shift.t)],
+                 int(e.shift.n));
     } break;
 
     case inst_type::EXTEND_ADD_SIGNED_BYTE: {
-      auto const& e{i.i.extend_add_signed_byte};
-      NL_LOG_DBG("SXTAB %s, %s, %s, <%d>", rn_mask(i.dr), s_rn[e.n], s_rn[e.m],
-        int(e.rotation));
+      auto const& e{ i.i.extend_add_signed_byte };
+      NL_LOG_DBG("SXTAB %s, %s, %s, <%d>",
+                 rn_mask(i.dr),
+                 s_rn[e.n],
+                 s_rn[e.m],
+                 int(e.rotation));
     } break;
 
     case inst_type::EXTEND_ADD_SIGNED_HALF: {
-      auto const& e{i.i.extend_add_signed_half};
-      NL_LOG_DBG("SXTAH %s, %s, %s, <%d>", rn_mask(i.dr), s_rn[e.n], s_rn[e.m],
-        int(e.rotation));
+      auto const& e{ i.i.extend_add_signed_half };
+      NL_LOG_DBG("SXTAH %s, %s, %s, <%d>",
+                 rn_mask(i.dr),
+                 s_rn[e.n],
+                 s_rn[e.m],
+                 int(e.rotation));
     } break;
 
     case inst_type::EXTEND_ADD_UNSIGNED_BYTE: {
-      auto const& e{i.i.extend_add_unsigned_byte};
-      NL_LOG_DBG("UXTAB %s, %s, %s, <%d>", rn_mask(i.dr), s_rn[e.n], s_rn[e.m],
-        int(e.rotation));
+      auto const& e{ i.i.extend_add_unsigned_byte };
+      NL_LOG_DBG("UXTAB %s, %s, %s, <%d>",
+                 rn_mask(i.dr),
+                 s_rn[e.n],
+                 s_rn[e.m],
+                 int(e.rotation));
     } break;
 
     case inst_type::EXTEND_SIGNED_BYTE: {
-      auto const& e{i.i.extend_signed_byte};
+      auto const& e{ i.i.extend_signed_byte };
       NL_LOG_DBG("SXTB %s, %s, <%d>", rn_mask(i.dr), s_rn[e.m], int(e.rotation));
     } break;
 
     case inst_type::EXTEND_SIGNED_HALF: {
-      auto const& e{i.i.extend_signed_half};
+      auto const& e{ i.i.extend_signed_half };
       NL_LOG_DBG("SXTH %s, %s, <%d>", rn_mask(i.dr), s_rn[e.m], int(e.rotation));
     } break;
 
     case inst_type::EXTEND_UNSIGNED_BYTE: {
-      auto const& u{i.i.extend_unsigned_byte};
+      auto const& u{ i.i.extend_unsigned_byte };
       NL_LOG_DBG("UXTB %s, %s, <%d>", rn_mask(i.dr), s_rn[u.m], int(u.rotation));
     } break;
 
     case inst_type::EXTEND_UNSIGNED_HALF: {
-      auto const& u{i.i.extend_unsigned_half};
+      auto const& u{ i.i.extend_unsigned_half };
       NL_LOG_DBG("UXTH %s, %s, <%d>", rn_mask(i.dr), s_rn[u.m], int(u.rotation));
     } break;
 
     case inst_type::EXTEND_ADD_UNSIGNED_HALF: {
-      auto const& u{i.i.extend_add_unsigned_half};
-      NL_LOG_DBG("UXTAH %s, %s, %s, <#%d>", rn_mask(i.dr), s_rn[u.n], s_rn[u.m],
-        int(u.rotation));
+      auto const& u{ i.i.extend_add_unsigned_half };
+      NL_LOG_DBG("UXTAH %s, %s, %s, <#%d>",
+                 rn_mask(i.dr),
+                 s_rn[u.n],
+                 s_rn[u.m],
+                 int(u.rotation));
     } break;
 
     case inst_type::IF_THEN: {
-      static char const *s_it[] = {
-        "???", "EEE", "EE", "EET", "E", "ETE", "ET", "ETT", "", "TEE", "TE", "TET", "T",
-        "TTE", "TT", "TTT" };
+      static char const* s_it[] = { "???", "EEE", "EE", "EET", "E", "ETE", "ET", "ETT",
+                                    "",    "TEE", "TE", "TET", "T", "TTE", "TT", "TTT" };
 
-      auto const& t{i.i.if_then};
+      auto const& t{ i.i.if_then };
       NL_LOG_DBG("IT%s %s", s_it[t.mask], cond_code_name(cond_code(t.firstcond)));
     } break;
 
     case inst_type::LOAD_BYTE_IMM: {
-      auto const& l{i.i.load_byte_imm};
+      auto const& l{ i.i.load_byte_imm };
       NL_LOG_DBG("LDRB_IMM %s, [%s, #%d]", rn_mask(i.dr), s_rn[l.n], int(l.imm));
     } break;
 
     case inst_type::LOAD_BYTE_LIT: {
-      auto const& l{i.i.load_byte_lit};
-      NL_LOG_DBG("LDRB_LIT %s, [%s, #%c%d]", rn_mask(i.dr), s_rn[reg::PC], l.add ? '+' : '-',
-        int(l.imm));
+      auto const& l{ i.i.load_byte_lit };
+      NL_LOG_DBG("LDRB_LIT %s, [%s, #%c%d]",
+                 rn_mask(i.dr),
+                 s_rn[reg::PC],
+                 l.add ? '+' : '-',
+                 int(l.imm));
     } break;
 
     case inst_type::LOAD_BYTE_REG: {
-      auto const& l{i.i.load_byte_reg};
-      NL_LOG_DBG("LDRB_REG %s, [%s, %s, %s #%d]", rn_mask(i.dr), s_rn[l.n], s_rn[l.m],
-        s_sn[int(l.shift.t)], int(l.shift.n));
+      auto const& l{ i.i.load_byte_reg };
+      NL_LOG_DBG("LDRB_REG %s, [%s, %s, %s #%d]",
+                 rn_mask(i.dr),
+                 s_rn[l.n],
+                 s_rn[l.m],
+                 s_sn[int(l.shift.t)],
+                 int(l.shift.n));
     } break;
 
     case inst_type::LOAD_DBL_REG: {
-      auto const& l{i.i.load_dbl_reg};
-      NL_LOG_DBG("LDRD_REG %s, %s, [%s, #%s%d]", rn_mask(i.dr), s_rn[l.t2], s_rn[l.n],
-        l.add ? "" : "-", int(l.imm));
+      auto const& l{ i.i.load_dbl_reg };
+      NL_LOG_DBG("LDRD_REG %s, %s, [%s, #%s%d]",
+                 rn_mask(i.dr),
+                 s_rn[l.t2],
+                 s_rn[l.n],
+                 l.add ? "" : "-",
+                 int(l.imm));
     } break;
 
     case inst_type::LOAD_EXCL: {
-      auto const& l{i.i.load_excl};
+      auto const& l{ i.i.load_excl };
       NL_LOG_DBG("LDREX %s, [%s, #%d]", rn_mask(i.dr), s_rn[l.n], int(l.imm));
     } break;
 
     case inst_type::LOAD_HALF_IMM: {
-      auto const& l{i.i.load_half_imm};
+      auto const& l{ i.i.load_half_imm };
       NL_LOG_DBG("LDRH_IMM %s, [%s, #%d]", rn_mask(i.dr), s_rn[l.n], int(l.imm));
     } break;
 
     case inst_type::LOAD_HALF_REG: {
-      auto const& l{i.i.load_half_reg};
-      NL_LOG_DBG("LDRH_REG %s, [%s, %s, %s #%d]", rn_mask(i.dr), s_rn[l.n], s_rn[l.m],
-        s_sn[int(l.shift.t)], int(l.shift.n));
+      auto const& l{ i.i.load_half_reg };
+      NL_LOG_DBG("LDRH_REG %s, [%s, %s, %s #%d]",
+                 rn_mask(i.dr),
+                 s_rn[l.n],
+                 s_rn[l.m],
+                 s_sn[int(l.shift.t)],
+                 int(l.shift.n));
     } break;
 
     case inst_type::LOAD_SIGNED_BYTE_IMM: {
-      auto const& l{i.i.load_signed_byte_imm};
+      auto const& l{ i.i.load_signed_byte_imm };
       NL_LOG_DBG("LDRSB_IMM %s, [%s, #%d]", rn_mask(i.dr), s_rn[l.n], int(l.imm));
     } break;
 
     case inst_type::LOAD_SIGNED_BYTE_REG: {
-      auto const& l{i.i.load_signed_byte_reg};
-      NL_LOG_DBG("LDRSB_REG %s, [%s, %s, %s #%d]", rn_mask(i.dr), s_rn[l.n], s_rn[l.m],
-        s_sn[int(l.shift.t)], int(l.shift.n));
+      auto const& l{ i.i.load_signed_byte_reg };
+      NL_LOG_DBG("LDRSB_REG %s, [%s, %s, %s #%d]",
+                 rn_mask(i.dr),
+                 s_rn[l.n],
+                 s_rn[l.m],
+                 s_sn[int(l.shift.t)],
+                 int(l.shift.n));
     } break;
 
     case inst_type::LOAD_SIGNED_HALF_IMM: {
-      auto const& l{i.i.load_signed_half_imm};
-      NL_LOG_DBG("LDRSH_IMM %s, [%s, #%c%d]", rn_mask(i.dr), s_rn[l.n], l.add ? '+' : '-',
-        int(l.imm));
+      auto const& l{ i.i.load_signed_half_imm };
+      NL_LOG_DBG("LDRSH_IMM %s, [%s, #%c%d]",
+                 rn_mask(i.dr),
+                 s_rn[l.n],
+                 l.add ? '+' : '-',
+                 int(l.imm));
     } break;
 
     case inst_type::LOAD_SIGNED_HALF_REG: {
-      auto const& l{i.i.load_signed_half_reg};
-      NL_LOG_DBG("LDRSH_REG %s, [%s, %s, %s #%d]", rn_mask(i.dr), s_rn[l.n], s_rn[l.m],
-        s_sn[int(l.shift.t)], int(l.shift.n));
+      auto const& l{ i.i.load_signed_half_reg };
+      NL_LOG_DBG("LDRSH_REG %s, [%s, %s, %s #%d]",
+                 rn_mask(i.dr),
+                 s_rn[l.n],
+                 s_rn[l.m],
+                 s_sn[int(l.shift.t)],
+                 int(l.shift.n));
     } break;
 
     case inst_type::LOAD_IMM: {
-      auto const& l{i.i.load_imm};
+      auto const& l{ i.i.load_imm };
       NL_LOG_DBG("LDR_IMM %s, [%s, #%d]", rn_mask(i.dr), s_rn[l.n], int(l.imm));
     } break;
 
     case inst_type::LOAD_LIT: {
-      auto const& l{i.i.load_lit};
-      NL_LOG_DBG("LDR_LIT %s, [PC, #%s%d] (%x)", rn_mask(i.dr), l.add ? "" : "-", int(l.imm),
-        unsigned(l.addr));
+      auto const& l{ i.i.load_lit };
+      NL_LOG_DBG("LDR_LIT %s, [PC, #%s%d] (%x)",
+                 rn_mask(i.dr),
+                 l.add ? "" : "-",
+                 int(l.imm),
+                 unsigned(l.addr));
     } break;
 
     case inst_type::LOAD_MULT_DEC_BEFORE: {
-      auto const& l{i.i.load_mult_dec_before};
+      auto const& l{ i.i.load_mult_dec_before };
       NL_LOG_DBG("LDMDB %s%s, { ", s_rn[l.n], l.wback ? "!" : "");
-      for (int b{0}; b < 16; ++b) { if (i.dr & (1u << b)) { NL_LOG_DBG("%s ", s_rn[b]); } }
+      for (int b{ 0 }; b < 16; ++b) {
+        if (i.dr & (1u << b)) {
+          NL_LOG_DBG("%s ", s_rn[b]);
+        }
+      }
       NL_LOG_DBG("}");
     } break;
 
     case inst_type::LOAD_MULT_INC_AFTER: {
-      auto const& l{i.i.load_mult_inc_after};
+      auto const& l{ i.i.load_mult_inc_after };
       NL_LOG_DBG("LDMIA %s%s, { ", s_rn[l.n], l.wback ? "!" : "");
-      for (int b{0}; b < 16; ++b) { if (i.dr & (1u << b)) { NL_LOG_DBG("%s ", s_rn[b]); } }
+      for (int b{ 0 }; b < 16; ++b) {
+        if (i.dr & (1u << b)) {
+          NL_LOG_DBG("%s ", s_rn[b]);
+        }
+      }
       NL_LOG_DBG("}");
     } break;
 
     case inst_type::LOAD_REG: {
-      auto const& l{i.i.load_reg};
-      NL_LOG_DBG("LDR_REG %s, [%s, %s <%s #%d>]", rn_mask(i.dr), s_rn[l.n], s_rn[l.m],
-        s_sn[int(l.shift.t)], int(l.shift.n));
+      auto const& l{ i.i.load_reg };
+      NL_LOG_DBG("LDR_REG %s, [%s, %s <%s #%d>]",
+                 rn_mask(i.dr),
+                 s_rn[l.n],
+                 s_rn[l.m],
+                 s_sn[int(l.shift.t)],
+                 int(l.shift.n));
     } break;
 
     case inst_type::LSHIFT_LOG_IMM: {
-      auto const& l{i.i.lshift_log_imm};
+      auto const& l{ i.i.lshift_log_imm };
       NL_LOG_DBG("LSL_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[l.m], int(l.shift.n));
     } break;
 
     case inst_type::LSHIFT_LOG_REG: {
-      auto const& l{i.i.lshift_log_reg};
+      auto const& l{ i.i.lshift_log_reg };
       NL_LOG_DBG("LSL_REG %s, %s, %s", rn_mask(i.dr), s_rn[l.n], s_rn[l.m]);
     } break;
 
     case inst_type::MOV_REG: {
-      auto const& m{i.i.mov_reg};
+      auto const& m{ i.i.mov_reg };
       NL_LOG_DBG("MOV %s, %s", rn_mask(i.dr), s_rn[m.m]);
     } break;
 
     case inst_type::MOV_IMM: {
-      auto const& m{i.i.mov_imm};
+      auto const& m{ i.i.mov_imm };
       NL_LOG_DBG("MOV_IMM %s, #%d (%#x)", rn_mask(i.dr), int(m.imm), unsigned(m.imm));
     } break;
 
     case inst_type::MOV_NEG_IMM: {
-      auto const& m{i.i.mov_neg_imm};
-      NL_LOG_DBG("MOV_NEG_IMM %s, #%d (%#x)", rn_mask(i.dr), unsigned(m.imm),
-        unsigned(m.imm));
+      auto const& m{ i.i.mov_neg_imm };
+      NL_LOG_DBG("MOV_NEG_IMM %s, #%d (%#x)",
+                 rn_mask(i.dr),
+                 unsigned(m.imm),
+                 unsigned(m.imm));
     } break;
 
     case inst_type::MOV_NEG_REG: {
-      auto const& m{i.i.mov_neg_reg};
-      NL_LOG_DBG("MOV_NEG_REG %s, %s, %s #%d", rn_mask(i.dr), s_rn[m.m],
-        s_sn[int(m.shift.t)], int(m.shift.n));
+      auto const& m{ i.i.mov_neg_reg };
+      NL_LOG_DBG("MOV_NEG_REG %s, %s, %s #%d",
+                 rn_mask(i.dr),
+                 s_rn[m.m],
+                 s_sn[int(m.shift.t)],
+                 int(m.shift.n));
     } break;
 
     case inst_type::MUL: {
-      auto const& m{i.i.mul};
+      auto const& m{ i.i.mul };
       NL_LOG_DBG("MUL %s, %s, %s", rn_mask(i.dr), s_rn[m.n], s_rn[m.m]);
     } break;
 
     case inst_type::MUL_ACCUM: {
-      auto const& m{i.i.mul_accum};
+      auto const& m{ i.i.mul_accum };
       NL_LOG_DBG("MLA %s, %s, %s, %s", rn_mask(i.dr), s_rn[m.n], s_rn[m.m], s_rn[m.a]);
     } break;
 
     case inst_type::MUL_ACCUM_SIGNED_HALF: {
-      auto const& m{i.i.mul_accum_signed_half};
-      NL_LOG_DBG("SMLA%c%c %s, %s, %s, %s", "BT"[m.n_high], "BT"[m.m_high],
-        rn_mask(i.dr), s_rn[m.n], s_rn[m.m], s_rn[m.a]);
+      auto const& m{ i.i.mul_accum_signed_half };
+      NL_LOG_DBG("SMLA%c%c %s, %s, %s, %s",
+                 "BT"[m.n_high],
+                 "BT"[m.m_high],
+                 rn_mask(i.dr),
+                 s_rn[m.n],
+                 s_rn[m.m],
+                 s_rn[m.a]);
     } break;
 
     case inst_type::MUL_ACCUM_SIGNED_LONG: {
-      auto const& m{i.i.mul_accum_signed_long};
+      auto const& m{ i.i.mul_accum_signed_long };
       NL_LOG_DBG("SMLAL %s, %s, %s, %s", s_rn[m.dlo], s_rn[m.dhi], s_rn[m.n], s_rn[m.m]);
     } break;
 
     case inst_type::MUL_ACCUM_UNSIGNED_LONG: {
-      auto const& m{i.i.mul_accum_unsigned_long};
+      auto const& m{ i.i.mul_accum_unsigned_long };
       NL_LOG_DBG("UMLAL %s, %s, %s, %s", s_rn[m.dlo], s_rn[m.dhi], s_rn[m.n], s_rn[m.m]);
     } break;
 
     case inst_type::MUL_SIGNED_HALF: {
-      auto const& m{i.i.mul_signed_half};
-      NL_LOG_DBG("SMUL%c%c %s, %s, %s", "BT"[m.n_high], "BT"[m.m_high], rn_mask(i.dr),
-        s_rn[m.n], s_rn[m.m]);
+      auto const& m{ i.i.mul_signed_half };
+      NL_LOG_DBG("SMUL%c%c %s, %s, %s",
+                 "BT"[m.n_high],
+                 "BT"[m.m_high],
+                 rn_mask(i.dr),
+                 s_rn[m.n],
+                 s_rn[m.m]);
     } break;
 
     case inst_type::MUL_SIGNED_LONG: {
-      auto const& m{i.i.mul_signed_long};
+      auto const& m{ i.i.mul_signed_long };
       NL_LOG_DBG("SMULL %s, %s, %s, %s", s_rn[m.dlo], s_rn[m.dhi], s_rn[m.n], s_rn[m.m]);
     } break;
 
     case inst_type::MUL_SUB: {
-      auto const& m{i.i.mul_sub};
+      auto const& m{ i.i.mul_sub };
       NL_LOG_DBG("MLS %s, %s, %s, %s", rn_mask(i.dr), s_rn[m.n], s_rn[m.m], s_rn[m.a]);
     } break;
 
     case inst_type::MUL_UNSIGNED_LONG: {
-      auto const& m{i.i.mul_unsigned_long};
+      auto const& m{ i.i.mul_unsigned_long };
       NL_LOG_DBG("UMULL %s, %s, %s, %s", s_rn[m.dlo], s_rn[m.dhi], s_rn[m.n], s_rn[m.m]);
     } break;
 
-    case inst_type::NOP: NL_LOG_DBG("NOP"); break;
+    case inst_type::NOP:
+      NL_LOG_DBG("NOP");
+      break;
 
     case inst_type::OR_NOT_REG: {
-      auto const& o{i.i.or_not_reg};
-      NL_LOG_DBG("ORN_REG %s, %s, %s, %s #%d", rn_mask(i.dr), s_rn[o.n], s_rn[o.m],
-        s_sn[int(o.shift.t)], int(o.shift.n));
+      auto const& o{ i.i.or_not_reg };
+      NL_LOG_DBG("ORN_REG %s, %s, %s, %s #%d",
+                 rn_mask(i.dr),
+                 s_rn[o.n],
+                 s_rn[o.m],
+                 s_sn[int(o.shift.t)],
+                 int(o.shift.n));
     } break;
 
     case inst_type::OR_IMM: {
-      auto const& o{i.i.or_imm};
+      auto const& o{ i.i.or_imm };
       NL_LOG_DBG("ORR_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[o.n], int(o.imm));
     } break;
 
     case inst_type::OR_REG: {
-      auto const& o{i.i.or_reg};
-      NL_LOG_DBG("ORR_REG %s, %s, %s <%s #%d>", rn_mask(i.dr), s_rn[o.n], s_rn[o.m],
-        s_sn[int(o.shift.t)], int(o.shift.n));
+      auto const& o{ i.i.or_reg };
+      NL_LOG_DBG("ORR_REG %s, %s, %s <%s #%d>",
+                 rn_mask(i.dr),
+                 s_rn[o.n],
+                 s_rn[o.m],
+                 s_sn[int(o.shift.t)],
+                 int(o.shift.n));
     } break;
 
     case inst_type::PACK_HALF: {
-      auto const& p{i.i.pack_half};
-      NL_LOG_DBG("PKH%s %s, %s, %s, %s #%d", p.tbform ? "TB" : "BT", rn_mask(i.dr),
-        s_rn[p.n], s_rn[p.m], s_sn[int(p.shift.t)], int(p.shift.n));
+      auto const& p{ i.i.pack_half };
+      NL_LOG_DBG("PKH%s %s, %s, %s, %s #%d",
+                 p.tbform ? "TB" : "BT",
+                 rn_mask(i.dr),
+                 s_rn[p.n],
+                 s_rn[p.m],
+                 s_sn[int(p.shift.t)],
+                 int(p.shift.n));
     } break;
 
     case inst_type::PUSH: {
       NL_LOG_DBG("PUSH { ");
-      for (auto b{0}; b < 16; ++b) {
-        if (i.i.push.reg_list & (1u << b)) { NL_LOG_DBG("%s ", s_rn[b]); }
+      for (auto b{ 0 }; b < 16; ++b) {
+        if (i.i.push.reg_list & (1u << b)) {
+          NL_LOG_DBG("%s ", s_rn[b]);
+        }
       }
       NL_LOG_DBG("}");
     } break;
 
     case inst_type::POP: {
       NL_LOG_DBG("POP { ");
-      for (auto b{0}; b < 16; ++b) { if (i.dr & (1u << b)) { NL_LOG_DBG("%s ", s_rn[b]); } }
+      for (auto b{ 0 }; b < 16; ++b) {
+        if (i.dr & (1u << b)) {
+          NL_LOG_DBG("%s ", s_rn[b]);
+        }
+      }
       NL_LOG_DBG("}");
     } break;
 
     case inst_type::REVERSE_BITS: {
-      auto const& r{i.i.reverse_bits}; NL_LOG_DBG("RBIT %s, %s", rn_mask(i.dr), s_rn[r.m]);
+      auto const& r{ i.i.reverse_bits };
+      NL_LOG_DBG("RBIT %s, %s", rn_mask(i.dr), s_rn[r.m]);
     } break;
 
     case inst_type::RSHIFT_ARITH_IMM: {
-      auto const& r{i.i.rshift_arith_imm};
+      auto const& r{ i.i.rshift_arith_imm };
       NL_LOG_DBG("ASR_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[r.m], int(r.shift.n));
     } break;
 
     case inst_type::RSHIFT_ARITH_REG: {
-      auto const& r{i.i.rshift_arith_reg};
+      auto const& r{ i.i.rshift_arith_reg };
       NL_LOG_DBG("ASR_REG %s, %s, %s", rn_mask(i.dr), s_rn[r.n], s_rn[r.m]);
     } break;
 
     case inst_type::RSHIFT_LOG_IMM: {
-      auto const& r{i.i.rshift_log_imm};
+      auto const& r{ i.i.rshift_log_imm };
       NL_LOG_DBG("LSR_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[r.m], int(r.shift.n));
     } break;
 
     case inst_type::RSHIFT_LOG_REG: {
-      auto const& r{i.i.rshift_log_reg};
+      auto const& r{ i.i.rshift_log_reg };
       NL_LOG_DBG("LSR_REG %s, %s, %s", rn_mask(i.dr), s_rn[r.m], s_rn[r.n]);
     } break;
 
     case inst_type::SATURATE_UNSIGNED: {
-      auto const& s{i.i.saturate_unsigned};
-      NL_LOG_DBG("USAT %s, #%d, %s <%s #%d>", rn_mask(i.dr), int(s.saturate_to), s_rn[s.n],
-        s_sn[int(s.shift.t)], int(s.shift.n));
+      auto const& s{ i.i.saturate_unsigned };
+      NL_LOG_DBG("USAT %s, #%d, %s <%s #%d>",
+                 rn_mask(i.dr),
+                 int(s.saturate_to),
+                 s_rn[s.n],
+                 s_sn[int(s.shift.t)],
+                 int(s.shift.n));
     } break;
 
     case inst_type::SELECT_BYTES: {
-      auto const& s{i.i.select_bytes};
+      auto const& s{ i.i.select_bytes };
       NL_LOG_DBG("SEL %s, %s, %s", rn_mask(i.dr), s_rn[s.n], s_rn[s.m]);
     } break;
 
     case inst_type::STORE_BYTE_IMM: {
-      auto const& s{i.i.store_byte_imm};
-      NL_LOG_DBG("STRB_IMM %s, [%s, #%c%d]", s_rn[s.t], s_rn[s.n], s.add ? '+' : '-',
-        int(s.imm));
+      auto const& s{ i.i.store_byte_imm };
+      NL_LOG_DBG("STRB_IMM %s, [%s, #%c%d]",
+                 s_rn[s.t],
+                 s_rn[s.n],
+                 s.add ? '+' : '-',
+                 int(s.imm));
     } break;
 
     case inst_type::STORE_BYTE_REG: {
-      auto const& s{i.i.store_byte_reg};
-      NL_LOG_DBG("STRB_REG %s, [%s, %s, %s #%d]", s_rn[s.t], s_rn[s.n], s_rn[s.m],
-        s_sn[int(s.shift.t)], int(s.shift.n));
+      auto const& s{ i.i.store_byte_reg };
+      NL_LOG_DBG("STRB_REG %s, [%s, %s, %s #%d]",
+                 s_rn[s.t],
+                 s_rn[s.n],
+                 s_rn[s.m],
+                 s_sn[int(s.shift.t)],
+                 int(s.shift.n));
     } break;
 
     case inst_type::STORE_BYTE_UNPRIV: {
-      auto const& s{i.i.store_byte_unpriv};
+      auto const& s{ i.i.store_byte_unpriv };
       NL_LOG_DBG("STRBT %s, [%s, #%d]", s_rn[s.t], s_rn[s.n], int(s.imm));
     } break;
 
     case inst_type::STORE_DOUBLE_IMM: {
-      auto const& s{i.i.store_double_imm};
+      auto const& s{ i.i.store_double_imm };
       NL_LOG_DBG("STRD %s, %s, [%s], #%d", s_rn[s.t], s_rn[s.t2], s_rn[s.n], int(s.imm));
     } break;
 
     case inst_type::STORE_EXCL: {
-      auto const& s{i.i.store_excl};
+      auto const& s{ i.i.store_excl };
       NL_LOG_DBG("STREX %s, %s, [%s, #%d]", s_rn[s.d], s_rn[s.t], s_rn[s.n], int(s.imm));
     } break;
 
     case inst_type::STORE_HALF_IMM: {
-      auto const& s{i.i.store_half_imm};
-      NL_LOG_DBG("STRH %s, [%s, #%c%d]", s_rn[s.t], s_rn[s.n], s.add ? '+' : '-',
-        int(s.imm));
+      auto const& s{ i.i.store_half_imm };
+      NL_LOG_DBG("STRH %s, [%s, #%c%d]",
+                 s_rn[s.t],
+                 s_rn[s.n],
+                 s.add ? '+' : '-',
+                 int(s.imm));
     } break;
 
     case inst_type::STORE_HALF_REG: {
-      auto const& s{i.i.store_half_reg};
-      NL_LOG_DBG("STRH %s, [%s, %s, %s #%d]", s_rn[s.t], s_rn[s.n], s_rn[s.m],
-        s_sn[int(s.shift.t)], int(s.shift.n));
+      auto const& s{ i.i.store_half_reg };
+      NL_LOG_DBG("STRH %s, [%s, %s, %s #%d]",
+                 s_rn[s.t],
+                 s_rn[s.n],
+                 s_rn[s.m],
+                 s_sn[int(s.shift.t)],
+                 int(s.shift.n));
     } break;
 
     case inst_type::STORE_IMM: {
-      auto const& s{i.i.store_imm};
+      auto const& s{ i.i.store_imm };
       NL_LOG_DBG("STR_IMM %s, [%s, #%d]", s_rn[s.t], s_rn[s.n], int(s.imm));
     } break;
 
     case inst_type::STORE_MULT_DEC_BEFORE: {
-      auto const& s{i.i.store_mult_dec_before};
+      auto const& s{ i.i.store_mult_dec_before };
       NL_LOG_DBG("STMDB %s!, { ", s_rn[s.n]);
-      for (int b{0}; b < 16; ++b) {
-        if (s.regs & (1u << b)) { NL_LOG_DBG("%s ", s_rn[b]); }
+      for (int b{ 0 }; b < 16; ++b) {
+        if (s.regs & (1u << b)) {
+          NL_LOG_DBG("%s ", s_rn[b]);
+        }
       }
       NL_LOG_DBG("}");
     } break;
 
     case inst_type::STORE_MULT_INC_AFTER: {
-      auto const& s{i.i.store_mult_inc_after};
+      auto const& s{ i.i.store_mult_inc_after };
       NL_LOG_DBG("STMIA %s%s, { ", s_rn[s.n], s.wback ? "!" : "");
-      for (int b{0}; b < 16; ++b) {
-        if (s.regs & (1u << b)) { NL_LOG_DBG("%s ", s_rn[b]); }
+      for (int b{ 0 }; b < 16; ++b) {
+        if (s.regs & (1u << b)) {
+          NL_LOG_DBG("%s ", s_rn[b]);
+        }
       }
       NL_LOG_DBG("}");
     } break;
 
     case inst_type::STORE_REG: {
-      auto const& s{i.i.store_reg};
-      NL_LOG_DBG("STR_REG %s, [%s, %s <%s #%d>", s_rn[s.t], s_rn[s.n], s_rn[s.m],
-        s_sn[int(s.shift.t)], int(s.shift.n));
+      auto const& s{ i.i.store_reg };
+      NL_LOG_DBG("STR_REG %s, [%s, %s <%s #%d>",
+                 s_rn[s.t],
+                 s_rn[s.n],
+                 s_rn[s.m],
+                 s_sn[int(s.shift.t)],
+                 int(s.shift.n));
     } break;
 
     case inst_type::SUB_IMM: {
-      auto const& s{i.i.sub_imm};
+      auto const& s{ i.i.sub_imm };
       NL_LOG_DBG("SUB_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[s.n], int(s.imm));
     } break;
 
     case inst_type::SUB_IMM_CARRY: {
-      auto const& s{i.i.sub_imm_carry};
+      auto const& s{ i.i.sub_imm_carry };
       NL_LOG_DBG("SUB_IMM_CARRY %s, %s, #%d", rn_mask(i.dr), s_rn[s.n], int(s.imm));
     } break;
 
     case inst_type::SUB_REG: {
-      auto const& s{i.i.sub_reg};
-      NL_LOG_DBG("SUB_REG %s, %s, %s <%s #%u>", rn_mask(i.dr), s_rn[s.n], s_rn[s.m],
-        s_sn[int(s.shift.t)], unsigned(s.shift.n));
+      auto const& s{ i.i.sub_reg };
+      NL_LOG_DBG("SUB_REG %s, %s, %s <%s #%u>",
+                 rn_mask(i.dr),
+                 s_rn[s.n],
+                 s_rn[s.m],
+                 s_sn[int(s.shift.t)],
+                 unsigned(s.shift.n));
     } break;
 
     case inst_type::SUB_REG_CARRY: {
-      auto const& s{i.i.sub_reg_carry};
-      NL_LOG_DBG("SUB_REG_CARRY %s, %s, %s <%s #%u>", rn_mask(i.dr), s_rn[s.n],
-        s_rn[s.m], s_sn[int(s.shift.t)], unsigned(s.shift.n));
+      auto const& s{ i.i.sub_reg_carry };
+      NL_LOG_DBG("SUB_REG_CARRY %s, %s, %s <%s #%u>",
+                 rn_mask(i.dr),
+                 s_rn[s.n],
+                 s_rn[s.m],
+                 s_sn[int(s.shift.t)],
+                 unsigned(s.shift.n));
     } break;
 
     case inst_type::SUB_REV_IMM: {
-      auto const& s{i.i.sub_rev_imm};
+      auto const& s{ i.i.sub_rev_imm };
       NL_LOG_DBG("RSB_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[s.n], int(s.imm));
     } break;
 
     case inst_type::SUB_REV_REG: {
-      auto const& s{i.i.sub_rev_reg};
-      NL_LOG_DBG("RSB_REG %s, %s, %s, %s #%d", rn_mask(i.dr), s_rn[s.n], s_rn[s.m],
-        s_sn[int(s.shift.t)], int(s.shift.n));
+      auto const& s{ i.i.sub_rev_reg };
+      NL_LOG_DBG("RSB_REG %s, %s, %s, %s #%d",
+                 rn_mask(i.dr),
+                 s_rn[s.n],
+                 s_rn[s.m],
+                 s_sn[int(s.shift.t)],
+                 int(s.shift.n));
     } break;
 
     case inst_type::SUB_SP_IMM: {
-      auto const& s{i.i.sub_sp_imm};
+      auto const& s{ i.i.sub_sp_imm };
       NL_LOG_DBG("SUB_IMM %s, %s, #%d", rn_mask(i.dr), s_rn[reg::SP], int(s.imm));
     } break;
 
-    case inst_type::SVC: NL_LOG_DBG("SVC %x", unsigned(i.i.svc.imm)); break;
+    case inst_type::SVC:
+      NL_LOG_DBG("SVC %x", unsigned(i.i.svc.imm));
+      break;
 
     case inst_type::TABLE_BRANCH_BYTE: {
-      auto const& t{i.i.table_branch_byte};
+      auto const& t{ i.i.table_branch_byte };
       NL_LOG_DBG("TBB [%s, %s]", s_rn[t.n], s_rn[t.m]);
     } break;
 
     case inst_type::TABLE_BRANCH_HALF: {
-      auto const& t{i.i.table_branch_half};
+      auto const& t{ i.i.table_branch_half };
       NL_LOG_DBG("TBH [%s, %s]", s_rn[t.n], s_rn[t.m]);
     } break;
 
     case inst_type::TEST_EQUIV_IMM: {
-      auto const& t{i.i.test_equiv_imm};
+      auto const& t{ i.i.test_equiv_imm };
       NL_LOG_DBG("TEQ_IMM %s, #%d", s_rn[t.n], int(t.imm));
     } break;
 
     case inst_type::TEST_EQUIV_REG: {
-      auto const& t{i.i.test_equiv_reg};
+      auto const& t{ i.i.test_equiv_reg };
       NL_LOG_DBG("TEQ_REG %s, %s", s_rn[t.n], s_rn[t.m]);
     } break;
 
     case inst_type::TEST_REG: {
-      auto const& t{i.i.test_reg};
-      NL_LOG_DBG("TST %s, %s, %s #%d", s_rn[t.n], s_rn[t.m], s_sn[int(t.shift.t)],
-        int(t.shift.n));
+      auto const& t{ i.i.test_reg };
+      NL_LOG_DBG("TST %s, %s, %s #%d",
+                 s_rn[t.n],
+                 s_rn[t.m],
+                 s_sn[int(t.shift.t)],
+                 int(t.shift.n));
     } break;
 
-    case inst_type::UNDEFINED: NL_LOG_DBG("UDF"); break;
+    case inst_type::UNDEFINED:
+      NL_LOG_DBG("UDF");
+      break;
 
     case inst_type::VADD: {
-      auto const& v{i.i.vadd};
+      auto const& v{ i.i.vadd };
       NL_LOG_DBG("VADD.F32 S%d, S%d, S%d", int(v.d), int(v.n), int(v.m));
     } break;
 
     case inst_type::VCOMPARE: {
-      auto const& v{i.i.vcompare};
+      auto const& v{ i.i.vcompare };
       NL_LOG_DBG("VCMP%s.F32 S%d, ", v.quiet_nan_exc ? "E" : "", int(v.d));
-      if (v.with_zero) { NL_LOG_DBG("#0.0"); } else { NL_LOG_DBG("S%d", int(v.m)); }
+      if (v.with_zero) {
+        NL_LOG_DBG("#0.0");
+      } else {
+        NL_LOG_DBG("S%d", int(v.m));
+      }
     } break;
 
     case inst_type::VCONVERT_FP_INT: {
-      auto const& v{i.i.vconvert_fp_int};
+      auto const& v{ i.i.vconvert_fp_int };
       NL_LOG_DBG("VCVT.");
       NL_LOG_DBG("%c32.", v.to_int ? (v.int_unsigned ? 'U' : 'S') : 'F');
       NL_LOG_DBG("%c32 ", v.to_int ? 'F' : (v.int_unsigned ? 'U' : 'S'));
@@ -2640,38 +3042,41 @@ void inst_print(inst const& i) {
     } break;
 
     case inst_type::VDIV: {
-      auto const& v{i.i.vdiv};
+      auto const& v{ i.i.vdiv };
       NL_LOG_DBG("VDIV S%d, S%d, S%d", int(v.d), int(v.n), int(v.m));
     } break;
 
     case inst_type::VMULT_ACCUM: {
-      auto const& v{i.i.vmult_accum};
-      NL_LOG_DBG("VFM%c.F32 S%d, S%d, S%d", v.op1_neg ? 'S' : 'A', int(v.d), int(v.n),
-        int(v.m));
+      auto const& v{ i.i.vmult_accum };
+      NL_LOG_DBG("VFM%c.F32 S%d, S%d, S%d",
+                 v.op1_neg ? 'S' : 'A',
+                 int(v.d),
+                 int(v.n),
+                 int(v.m));
     } break;
 
     case inst_type::VLOAD: {
-      auto const& v{i.i.vload};
+      auto const& v{ i.i.vload };
       NL_LOG_DBG("VLDR S%d, [%s, #%d]", int(v.d), s_rn[v.n], int(v.imm));
     } break;
 
     case inst_type::VLOAD_MULT: {
-      auto const& v{i.i.vload_mult};
+      auto const& v{ i.i.vload_mult };
       NL_LOG_DBG("VLDM%s %s, {%x}", v.add ? "IA" : "DB", s_rn[v.n], unsigned(v.regs));
     } break;
 
     case inst_type::VMOV_IMM: {
-      auto const& v{i.i.vmov_imm};
+      auto const& v{ i.i.vmov_imm };
       NL_LOG_DBG("VMOV_IMM.F32 S%d, #%f", int(v.d), double(v.imm));
     } break;
 
     case inst_type::VMOV_REG: {
-      auto const& v{i.i.vmov_reg};
+      auto const& v{ i.i.vmov_reg };
       NL_LOG_DBG("VMOV_REG.F32 S%d, S%d", int(v.d), int(v.m));
     } break;
 
     case inst_type::VMOV_REG_DOUBLE: {
-      auto const& v{i.i.vmov_reg_double};
+      auto const& v{ i.i.vmov_reg_double };
       if (v.to_arm_regs) {
         NL_LOG_DBG("VMOV %s, %s, D%u", s_rn[v.t], s_rn[v.t2], unsigned(v.m));
       } else {
@@ -2680,7 +3085,7 @@ void inst_print(inst const& i) {
     } break;
 
     case inst_type::VMOV_REG_SINGLE: {
-      auto const& v{i.i.vmov_reg_single};
+      auto const& v{ i.i.vmov_reg_single };
       if (v.to_arm_reg) {
         NL_LOG_DBG("VMOV %s, S%u", s_rn[v.t], unsigned(v.n));
       } else {
@@ -2689,56 +3094,61 @@ void inst_print(inst const& i) {
     } break;
 
     case inst_type::VMOV_SPECIAL_FROM: {
-      auto const& v{i.i.vmov_special_from};
+      auto const& v{ i.i.vmov_special_from };
       NL_LOG_DBG("VMRS %s, FPSCR", v.t == 0b1111 ? "APSR_nzcv" : s_rn[v.t]);
     } break;
 
     case inst_type::VMOV_SPECIAL_TO: {
-      auto const& v{i.i.vmov_special_to};
+      auto const& v{ i.i.vmov_special_to };
       NL_LOG_DBG("VMSR FPSCR, %s", s_rn[v.t]);
     } break;
 
     case inst_type::VMUL: {
-      auto const& v{i.i.vmul};
+      auto const& v{ i.i.vmul };
       NL_LOG_DBG("VMUL.F32 S%d, S%d, S%d", int(v.d), int(v.n), int(v.m));
     } break;
 
     case inst_type::VNEG: {
-      auto const& v{i.i.vneg};
+      auto const& v{ i.i.vneg };
       NL_LOG_DBG("VNEG.F32 S%d, S%d", int(v.d), int(v.m));
     } break;
 
     case inst_type::VPOP: {
-      auto const& v{i.i.vpop};
-      NL_LOG_DBG("VPOP { %x }", v.regs); // TODO: print the list, don't care right now
+      auto const& v{ i.i.vpop };
+      NL_LOG_DBG("VPOP { %x }", v.regs);  // TODO: print the list, don't care right now
     } break;
 
     case inst_type::VPUSH: {
-      auto const& v{i.i.vpush};
-      NL_LOG_DBG("VPUSH { %x }", v.regs); // TODO: print the list, don't care right now
+      auto const& v{ i.i.vpush };
+      NL_LOG_DBG("VPUSH { %x }", v.regs);  // TODO: print the list, don't care right now
     } break;
 
     case inst_type::VSTORE: {
-      auto const& v{i.i.vstore};
-      NL_LOG_DBG("VSTR %c%d, [%s, #%d]", v.single_reg ? 'S' : 'D', int(v.d), s_rn[v.n],
-        int(v.imm));
+      auto const& v{ i.i.vstore };
+      NL_LOG_DBG("VSTR %c%d, [%s, #%d]",
+                 v.single_reg ? 'S' : 'D',
+                 int(v.d),
+                 s_rn[v.n],
+                 int(v.imm));
     } break;
 
     case inst_type::VSTORE_MULT: {
-      auto const& v{i.i.vstore_mult};
-      NL_LOG_DBG("VSTM%s %s%s, { %x }", v.add ? "IA" : "DB", s_rn[v.n], v.wb ? "!" : "",
-        unsigned(v.list));
+      auto const& v{ i.i.vstore_mult };
+      NL_LOG_DBG("VSTM%s %s%s, { %x }",
+                 v.add ? "IA" : "DB",
+                 s_rn[v.n],
+                 v.wb ? "!" : "",
+                 unsigned(v.list));
     } break;
 
     case inst_type::VSUB: {
-      auto const& v{i.i.vsub};
+      auto const& v{ i.i.vsub };
       NL_LOG_DBG("VSUB S%d, S%d, S%d", int(v.d), int(v.n), int(v.m));
     } break;
 
     case inst_type::VSQRT: {
-      auto const& v{i.i.vsqrt};
+      auto const& v{ i.i.vsqrt };
       NL_LOG_DBG("VSQRT.F32 S%d, S%d", int(v.d), int(v.m));
     } break;
   }
 }
-

--- a/unclog/thumb2_inst.h
+++ b/unclog/thumb2_inst.h
@@ -4,20 +4,25 @@
 
 // Condition Codes
 
+// clang-format off
 #define CONDITION_CODE_X_LIST() \
   X(EQ, 0b0000) X(NE, 0b0001) X(CS, 0b0010) X(CC, 0b0011) \
   X(MI, 0b0100) X(PL, 0b0101) X(VS, 0b0110) X(VC, 0b0111) \
   X(HS, 0b1000) X(LS, 0b1001) X(GE, 0b1010) X(LT, 0b1011) \
   X(GT, 0b1100) X(LE, 0b1101) X(AL1, 0b1110) X(AL2, 0b1111)
+// clang-format on
 
 #define X(NAME, VAL) NAME = VAL,
 enum class cond_code : u8 { CONDITION_CODE_X_LIST() };
 #undef X
 
-inline bool cond_code_is_always(cond_code cc) { return cc >= cond_code::AL1; }
+inline bool cond_code_is_always(cond_code cc) {
+  return cc >= cond_code::AL1;
+}
 
 // Registers
 
+// clang-format off
 #define REGISTER_X_LIST() \
   X(R0) X(R1) X(R2) X(R3) X(R4) X(R5) X(R6) X(R7) X(R8) X(R9) X(R10) X(R11) X(R12) \
   X(SP) X(LR) X(PC)
@@ -25,21 +30,28 @@ inline bool cond_code_is_always(cond_code cc) { return cc >= cond_code::AL1; }
 #define X(NAME) NAME,
 namespace reg { enum reg_e : u8 { REGISTER_X_LIST() }; }
 #undef X
+// clang-format on
 
-char const *reg_name(int reg);
+char const* reg_name(int reg);
 
 // Immediate Shift
 
+// clang-format off
 #define SHIFT_X_LIST() X(LSL) X(LSR) X(ASR) X(RRX) X(ROR)
 
 #define X(NAME) NAME,
 enum class imm_shift_type : u8 { SHIFT_X_LIST() };
 #undef X
+// clang-format on
 
-struct imm_shift { imm_shift_type t; u8 n; };
+struct imm_shift {
+  imm_shift_type t;
+  u8 n;
+};
 
 // Instructions
 
+// clang-format off
 #define INST_TYPE_X_LIST() \
   X(UNKNOWN, unknown, {}) \
   X(ADD_CARRY_IMM, add_carry_imm, { u32 imm; u8 n; }) \
@@ -177,6 +189,7 @@ struct imm_shift { imm_shift_type t; u8 n; };
   X(VSTORE_MULT, vstore_mult, { u16 imm; u8 n, d, list, wb, single_regs, add; }) \
   X(VSUB, vsub, { u8 d, n, m; }) \
   X(VSQRT, vsqrt, { u8 d, m; })
+// clang-format on
 
 #define X(ENUM, TYPE, ...) ENUM,
 enum class inst_type : u8 { INST_TYPE_X_LIST() };
@@ -188,17 +201,19 @@ INST_TYPE_X_LIST()
 
 struct inst {
 #define X(ENUM, TYPE, ...) inst_##TYPE TYPE;
-  union { INST_TYPE_X_LIST() } i;
+  union {
+    INST_TYPE_X_LIST()
+  } i;
 #undef X
   u32 addr;
-  u16 dr; // bitmask of destination registers r0-r15
+  u16 dr;  // bitmask of destination registers r0-r15
   u16 w0, w1;
   inst_type type;
-  u8 len; // 2 or 4
+  u8 len;  // 2 or 4
 };
 
 bool inst_is_unconditional_branch(inst const& i, u32& label);
 u32 inst_align(u32 val, u32 align);
-bool inst_decode(byte const *text, u32 func_addr, u32 pc_addr, inst& out_inst);
+bool inst_decode(byte const* text, u32 func_addr, u32 pc_addr, inst& out_inst);
 void inst_print(inst const& i);
 int inst_reg_from_bitmask(uint16_t reg_bitmask);


### PR DESCRIPTION
- early out upon encountering nanolog call, add clang-format and format runtime tests
- clang-format 4-space continuations
- format nanolog.c
- format nanolog.h
- more formatting
- more formatting
